### PR TITLE
Fix: Prevent process freeze during rumble on Linux & resolve pip conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,11 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-.idea
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# ruff
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -1,63 +1,77 @@
-# Virtual Gamepad
-Virtual XBox360 and DualShock4 gamepads in python.
+# vgamepad
+
+[![PyPI version](https://img.shields.io/pypi/v/vgamepad.svg)](https://pypi.org/project/vgamepad/)
+[![Python versions](https://img.shields.io/pypi/pyversions/vgamepad.svg)](https://pypi.org/project/vgamepad/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Virtual Xbox 360 and DualShock 4 gamepads in Python.
+
+`vgamepad` is a small Python library that emulates Xbox 360 and DualShock 4 gamepads on your system.
+It enables controlling e.g. a video-game that requires analog input, directly from your Python script.
+
+| Windows | Linux |
+|:-------:|:-----:|
+| Stable  | Stable |
+
+On **Windows**, `vgamepad` wraps Nefarius' [Virtual Gamepad Emulation](https://github.com/nefarius/ViGEmBus) C++ framework.
+On **Linux**, `vgamepad` uses `libevdev` to create virtual `uinput` devices.
 
 ---
 
-Virtual Gamepad (```vgamepad```) is a small python library that emulates XBox360 and DualShock4 gamepads on your system.
-It enables controlling e.g. a video-game that requires analog input, directly from your python script.
+## Table of Contents
 
-On Windows ```vgamepad``` uses the [Virtual Gamepad Emulation](https://github.com/nefarius/ViGEmBus) C++ framework, for which it essentially provides python bindings and a user-friendly interface.
-
----
-
-__Development status:__
-
-|  Windows  |                          Linux                          |
-|:---------:|:-------------------------------------------------------:|
-| *Stable.* | *Experimental,*<br/>see [Linux notes](readme/linux.md). |
-
-
-## Quick links
 - [Installation](#installation)
 - [Getting started](#getting-started)
-  - [XBox360 gamepad](#xbox360-gamepad)
-  - [DualShock4 gamepad](#dualshock4-gamepad)
+  - [Xbox 360 gamepad](#xbox-360-gamepad)
+  - [DualShock 4 gamepad](#dualshock-4-gamepad)
   - [Rumble and LEDs](#rumble-and-leds)
-- [Advanced](#advanced-users)
-- [Contribute](#authors)
+- [Logging](#logging)
+- [Advanced](#advanced)
+- [Contributing](#contributing)
 
 ---
 
 ## Installation
 
-### Windows:
-Open your favorite terminal (e.g. anaconda prompt) and run:
+### Windows
+
 ```bash
 pip install vgamepad
 ```
 
-This automatically runs the installer of the ViGEmBus driver.
-Accept the licence agreement, click ```Install```, allow the installer to modify you PC, wait for completion and click ```Finish```.
+This automatically runs the installer for the ViGEmBus driver.
+Accept the licence agreement, click **Install**, allow the installer to modify your PC, wait for completion and click **Finish**.
 
-```vgamepad``` is now installed in your active python environment.
+> To skip ViGEmBus installation, set the environment variable `VGAMEPAD_SKIP_VIGEMBUS_INSTALL=true` before installing.
 
-### Linux:
+### Linux
 
-Please read the [Linux section](readme/linux.md).
+See [Linux setup notes](readme/linux.md) for `uinput` permissions.
+
+```bash
+pip install vgamepad
+```
+
+### Development
+
+```bash
+pip install -e ".[dev]"
+```
+
+This installs `ruff`, `mypy`, `pytest`, and `pygame` for linting, type-checking and testing.
 
 ---
 
 ## Getting started
 
-```vgamepad``` provides two main python classes: ```VX360Gamepad```, which emulates a XBox360 gamepad, and ```VDS4Gamepad```, which emulates a DualShock4 gamepad.
+`vgamepad` provides two main classes: `VX360Gamepad` (Xbox 360) and `VDS4Gamepad` (DualShock 4).
 
-The state of a virtual gamepad (e.g. pressed buttons, joystick values...) is called a report.
-To modify the report, a number of user-friendly API functions are provided by ```vgamepad```.
-When the report is modified as desired, it must be sent to the computer thanks to the ```update``` API function.
+The state of a virtual gamepad (pressed buttons, joystick values, etc.) is called a **report**.
+Modify the report with the provided API functions, then call `update()` to send it.
 
-### XBox360 gamepad
+### Xbox 360 gamepad
 
-The following python script creates a virtual XBox360 gamepad:
+Create a virtual Xbox 360 gamepad:
 
 ```python
 import vgamepad as vg
@@ -65,31 +79,25 @@ import vgamepad as vg
 gamepad = vg.VX360Gamepad()
 ```
 
-As soon as the ```VX360Gamepad``` object is created, the virtual gamepad is connected to your system via the ViGEmBus driver, and will remain connected until the object is destroyed.
+As soon as the `VX360Gamepad` object is created, the virtual gamepad is connected and will remain connected until the object is destroyed.
 
-Buttons can be pressed and released through ```press_button``` and ```release_button```:
+Press and release buttons:
 
 ```python
-gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)  # press the A button
-gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_LEFT)  # press the left hat button
-
-gamepad.update()  # send the updated state to the computer
+gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
+gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_LEFT)
+gamepad.update()
 
 # (...) A and left hat are pressed...
 
-gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)  # release the A button
-
-gamepad.update()  # send the updated state to the computer
-
-# (...) left hat is still pressed...
+gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
+gamepad.update()
 ```
 
-All available buttons are defined in ```XUSB_BUTTON```:
+All available buttons are defined in `XUSB_BUTTON`:
+
 ```python
 class XUSB_BUTTON(IntFlag):
-    """
-    Possible XUSB report buttons.
-    """
     XUSB_GAMEPAD_DPAD_UP = 0x0001
     XUSB_GAMEPAD_DPAD_DOWN = 0x0002
     XUSB_GAMEPAD_DPAD_LEFT = 0x0004
@@ -107,43 +115,42 @@ class XUSB_BUTTON(IntFlag):
     XUSB_GAMEPAD_Y = 0x8000
 ```
 
-To control the triggers (1 axis each) and the joysticks (2 axis each), two options are provided by the API.
+Triggers and joysticks (raw integer values):
 
-It is possible to input raw integer values directly:
 ```python
-gamepad.left_trigger(value=100)  # value between 0 and 255
-gamepad.right_trigger(value=255)  # value between 0 and 255
-gamepad.left_joystick(x_value=-10000, y_value=0)  # values between -32768 and 32767
-gamepad.right_joystick(x_value=-32768, y_value=15000)  # values between -32768 and 32767
-
+gamepad.left_trigger(value=100)  # 0-255
+gamepad.right_trigger(value=255)  # 0-255
+gamepad.left_joystick(x_value=-10000, y_value=0)  # -32768 to 32767
+gamepad.right_joystick(x_value=-32768, y_value=15000)  # -32768 to 32767
 gamepad.update()
 ```
 
-Or to input float values:
-```python
-gamepad.left_trigger_float(value_float=0.5)  # value between 0.0 and 1.0
-gamepad.right_trigger_float(value_float=1.0)  # value between 0.0 and 1.0
-gamepad.left_joystick_float(x_value_float=-0.5, y_value_float=0.0)  # values between -1.0 and 1.0
-gamepad.right_joystick_float(x_value_float=-1.0, y_value_float=0.8)  # values between -1.0 and 1.0
+Triggers and joysticks (float values):
 
+```python
+gamepad.left_trigger_float(value_float=0.5)  # 0.0-1.0
+gamepad.right_trigger_float(value_float=1.0)  # 0.0-1.0
+gamepad.left_joystick_float(x_value_float=-0.5, y_value_float=0.0)  # -1.0 to 1.0
+gamepad.right_joystick_float(x_value_float=-1.0, y_value_float=0.8)  # -1.0 to 1.0
 gamepad.update()
 ```
 
 Reset to default state:
+
 ```python
 gamepad.reset()
-
 gamepad.update()
 ```
 
 Full example:
+
 ```python
 import vgamepad as vg
 import time
 
 gamepad = vg.VX360Gamepad()
 
-# press a button to wake the device up
+# Press a button to wake the device up
 gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
 gamepad.update()
 time.sleep(0.5)
@@ -151,7 +158,7 @@ gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
 gamepad.update()
 time.sleep(0.5)
 
-# press buttons and things
+# Press buttons and set axes
 gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
 gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER)
 gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_DOWN)
@@ -160,32 +167,27 @@ gamepad.left_trigger_float(value_float=0.5)
 gamepad.right_trigger_float(value_float=0.5)
 gamepad.left_joystick_float(x_value_float=0.0, y_value_float=0.2)
 gamepad.right_joystick_float(x_value_float=-1.0, y_value_float=1.0)
-
 gamepad.update()
-
 time.sleep(1.0)
 
-# release buttons and things
+# Release some buttons and axes
 gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
 gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_LEFT)
 gamepad.right_trigger_float(value_float=0.0)
 gamepad.right_joystick_float(x_value_float=0.0, y_value_float=0.0)
-
 gamepad.update()
-
 time.sleep(1.0)
 
-# reset gamepad to default state
+# Reset to default
 gamepad.reset()
-
 gamepad.update()
-
 time.sleep(1.0)
 ```
 
-### DualShock4 gamepad
+### DualShock 4 gamepad
 
-Using a virtual DS4 gamepad is similar to X360:
+Using a virtual DS4 gamepad is similar to Xbox 360:
+
 ```python
 import vgamepad as vg
 
@@ -193,22 +195,19 @@ gamepad = vg.VDS4Gamepad()
 ```
 
 Press and release buttons:
+
 ```python
 gamepad.press_button(button=vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE)
 gamepad.update()
-
-# (...)
 
 gamepad.release_button(button=vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE)
 gamepad.update()
 ```
 
-Available buttons are defined in ```DS4_BUTTONS```:
+Available buttons are defined in `DS4_BUTTONS`:
+
 ```python
 class DS4_BUTTONS(IntFlag):
-    """
-    DualShock 4 digital buttons
-    """
     DS4_BUTTON_THUMB_RIGHT = 1 << 15
     DS4_BUTTON_THUMB_LEFT = 1 << 14
     DS4_BUTTON_OPTIONS = 1 << 13
@@ -224,60 +223,56 @@ class DS4_BUTTONS(IntFlag):
 ```
 
 Press and release special buttons:
+
 ```python
 gamepad.press_special_button(special_button=vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS)
 gamepad.update()
-
-# (...)
 
 gamepad.release_special_button(special_button=vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS)
 gamepad.update()
 ```
 
-Special buttons are defined in ```DS4_SPECIAL_BUTTONS```:
+Special buttons are defined in `DS4_SPECIAL_BUTTONS`:
+
 ```python
 class DS4_SPECIAL_BUTTONS(IntFlag):
-    """
-    DualShock 4 special buttons
-    """
     DS4_SPECIAL_BUTTON_PS = 1 << 0
-    DS4_SPECIAL_BUTTON_TOUCHPAD = 1 << 1  # Windows only, no effect on Linux
+    DS4_SPECIAL_BUTTON_TOUCHPAD = 1 << 1
 ```
 
 Triggers and joysticks (integer values):
-```python
-gamepad.left_trigger(value=100)  # value between 0 and 255
-gamepad.right_trigger(value=255)  # value between 0 and 255
-gamepad.left_joystick(x_value=0, y_value=128)  # value between 0 and 255
-gamepad.right_joystick(x_value=0, y_value=255)  # value between 0 and 255
 
+```python
+gamepad.left_trigger(value=100)  # 0-255
+gamepad.right_trigger(value=255)  # 0-255
+gamepad.left_joystick(x_value=0, y_value=128)  # 0-255
+gamepad.right_joystick(x_value=0, y_value=255)  # 0-255
 gamepad.update()
 ```
 
 Triggers and joysticks (float values):
-```python
-gamepad.left_trigger_float(value_float=0.5)  # value between 0.0 and 1.0
-gamepad.right_trigger_float(value_float=1.0)  # value between 0.0 and 1.0
-gamepad.left_joystick_float(x_value_float=-0.5, y_value_float=0.0)  # values between -1.0 and 1.0
-gamepad.right_joystick_float(x_value_float=-1.0, y_value_float=0.8)  # values between -1.0 and 1.0
 
+```python
+gamepad.left_trigger_float(value_float=0.5)  # 0.0-1.0
+gamepad.right_trigger_float(value_float=1.0)  # 0.0-1.0
+gamepad.left_joystick_float(x_value_float=-0.5, y_value_float=0.0)  # -1.0 to 1.0
+gamepad.right_joystick_float(x_value_float=-1.0, y_value_float=0.8)  # -1.0 to 1.0
 gamepad.update()
 ```
 
-* **Note:** Since version `0.1.0`, the DS4 Y axis on joysticks is inverted compared to the X360 API (native VIGEm behavior).
+> **Note:** Since version 0.1.0, the DS4 Y axis on joysticks is inverted compared to the Xbox 360 API (native ViGEm behavior).
 
 Directional pad (hat):
+
 ```python
 gamepad.directional_pad(direction=vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST)
 gamepad.update()
 ```
 
-Directions for the directional pad are defined in ```DS4_DPAD_DIRECTIONS```:
+Directions for the directional pad are defined in `DS4_DPAD_DIRECTIONS`:
+
 ```python
 class DS4_DPAD_DIRECTIONS(IntEnum):
-    """
-    DualShock 4 directional pad (HAT) values
-    """
     DS4_BUTTON_DPAD_NONE = 0x8
     DS4_BUTTON_DPAD_NORTHWEST = 0x7
     DS4_BUTTON_DPAD_WEST = 0x6
@@ -290,20 +285,21 @@ class DS4_DPAD_DIRECTIONS(IntEnum):
 ```
 
 Reset to default state:
+
 ```python
 gamepad.reset()
-
 gamepad.update()
 ```
 
 Full example:
+
 ```python
 import vgamepad as vg
 import time
 
 gamepad = vg.VDS4Gamepad()
 
-# press a button to wake the device up
+# Press a button to wake the device up
 gamepad.press_button(button=vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE)
 gamepad.update()
 time.sleep(0.5)
@@ -311,7 +307,7 @@ gamepad.release_button(button=vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE)
 gamepad.update()
 time.sleep(0.5)
 
-# press buttons and things
+# Press buttons and set axes
 gamepad.press_button(button=vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE)
 gamepad.press_button(button=vg.DS4_BUTTONS.DS4_BUTTON_CIRCLE)
 gamepad.press_button(button=vg.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT)
@@ -321,41 +317,34 @@ gamepad.left_trigger_float(value_float=0.5)
 gamepad.right_trigger_float(value_float=0.5)
 gamepad.left_joystick_float(x_value_float=0.0, y_value_float=0.2)
 gamepad.right_joystick_float(x_value_float=-1.0, y_value_float=1.0)
-
 gamepad.update()
-
 time.sleep(1.0)
 
-# release buttons and things
+# Release some buttons and axes
 gamepad.release_button(button=vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE)
 gamepad.right_trigger_float(value_float=0.0)
 gamepad.right_joystick_float(x_value_float=0.0, y_value_float=0.0)
-
 gamepad.update()
-
 time.sleep(1.0)
 
-# reset gamepad to default state
+# Reset to default
 gamepad.reset()
-
 gamepad.update()
-
 time.sleep(1.0)
 ```
 
 ---
 
-### Rumble and LEDs:
+### Rumble and LEDs
 
-_**Note**: Rumble and LEDs are supported on Windows only (not yet ported to Linux)._
-
-`vgamepad` enables registering custom callback functions to handle updates of the rumble motors, and of the LED ring.
+`vgamepad` enables registering custom callback functions to handle updates of the rumble motors and the LED ring.
 
 Custom callback functions require 6 parameters:
+
 ```python
 def my_callback(client, target, large_motor, small_motor, led_number, user_data):
     """
-    Callback function triggered at each received state change
+    Callback function triggered at each received state change.
 
     :param client: vigem bus ID
     :param target: vigem device ID
@@ -364,55 +353,56 @@ def my_callback(client, target, large_motor, small_motor, led_number, user_data)
     :param led_number: integer in [0, 255] representing the state of the LED ring
     :param user_data: placeholder, do not use
     """
-    # Do your things here. For instance:
-    print(f"Received notification for client {client}, target {target}")
-    print(f"large motor: {large_motor}, small motor: {small_motor}")
-    print(f"led number: {led_number}")
+    print(f"large motor: {large_motor}, small motor: {small_motor}, led: {led_number}")
 ```
 
-The callback function needs to be registered as follows:
+Register the callback:
+
 ```python
 gamepad.register_notification(callback_function=my_callback)
 ```
 
-Each time the state of the gamepad is changed (for example by a video game that sends rumbling requests), the callback function will then be called.
+Each time the state of the gamepad is changed (e.g. by a video game sending rumble requests), the callback will be invoked.
 
-In our example, when state changes are received, something like the following will be printed to `stdout`:
-```terminal
-Received notification for client 2876897124288, target 2876931874736
-large motor: 255, small motor: 255
-led number: 0
-Received notification for client 2876897124288, target 2876931874736
-large motor: 0, small motor: 0
-led number: 0
-```
+If no longer needed, the callback can be unregistered:
 
-If not needed anymore, the callback function can be unregistered:
 ```python
 gamepad.unregister_notification()
 ```
 
 ---
 
-### Advanced users:
-More API functions are available for advanced users, and it is possible to modify the report directly instead of using the API.
-See [virtual_gamepad.py](https://github.com/yannbouteiller/vgamepad/blob/main/vgamepad/win/virtual_gamepad.py). 
+## Logging
 
-To skip installation of the `ViGEmBus` driver during `vgamepad` installation on Windows, set the `VGAMEPAD_SKIP_VIGEMBUS_INSTALL` environment variable to `true` before installing `vgamepad`.
+`vgamepad` uses [loguru](https://github.com/Delgan/loguru) for internal logging, which is **disabled** by default.
+To enable diagnostic output:
 
-_Note: only `ViGEmBus 1.17.333.0` is tested._
+```python
+from loguru import logger
+logger.enable("vgamepad")
+```
 
 ---
 
-## Contribute
+## Advanced
+
+More API functions are available for advanced users, and it is possible to modify the report directly instead of using the convenience API.
+See [virtual_gamepad.py](https://github.com/yannbouteiller/vgamepad/blob/main/vgamepad/win/virtual_gamepad.py).
+
+> Only ViGEmBus `1.17.333.0` is tested.
+
+---
+
+## Contributing
+
 All contributions to this project are welcome.
-Please submit a PR with your name and a short description of your contribution in the Contributors list.
+Please submit a pull request with your name and a short description of your contribution added to the list below.
 
----
-## Authors
-### Maintainer:
+### Maintainer
+
 - Yann Bouteiller
-### Contributors:
+
+### Contributors
 
 - JumpyzZ (rumble and LEDs)
 - willRicard (Linux support)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
     "Intended Audience :: Education",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,96 @@
 [build-system]
-requires = [
-    "setuptools",
-]
+requires = ["setuptools>=68.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "vgamepad"
+version = "0.1.3"
+description = "Virtual Xbox 360 and DualShock 4 gamepads in Python"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.8"
+authors = [
+    { name = "Yann Bouteiller" },
+]
+keywords = [
+    "virtual",
+    "gamepad",
+    "python",
+    "xbox",
+    "dualshock",
+    "controller",
+    "emulator",
+]
+dependencies = [
+    "loguru>=0.7",
+    "libevdev>=0.11,<1; sys_platform == 'linux'",
+]
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Games/Entertainment",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/yannbouteiller/vgamepad"
+Repository = "https://github.com/yannbouteiller/vgamepad"
+Issues = "https://github.com/yannbouteiller/vgamepad/issues"
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.4",
+    "mypy>=1.10",
+    "pytest>=8.0",
+    "pygame>=2.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["vgamepad*"]
+
+[tool.ruff]
+target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+    "RUF",    # ruff-specific
+]
+ignore = [
+    "E501",    # line too long (handled by formatter)
+    "UP007",   # X | Y union syntax (needs 3.10+)
+    "RUF012",  # mutable ClassVar (false positives on ctypes _fields_)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["vgamepad"]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true

--- a/readme/linux.md
+++ b/readme/linux.md
@@ -1,9 +1,6 @@
 # Linux
 
-`vgamepad` is partly supported on Linux since version `0.1.0`.
-
-Contrary to Windows, support for Linux is experimental and subject to future breaking changes.
-If your python project for Linux relies on `vgamepad`, please specify the exact version you are relying on in your project dependencies.
+`vgamepad` is fully supported on Linux.
 
 ## Installation
 
@@ -36,22 +33,23 @@ pip install vgamepad
 ```vgamepad``` is now installed in your active python environment.
 
 
-## Differences with Windows
-On Windows, `vgamepad` is currently a wrapper around Nefarius' [Virtual Gamepad Emulation](https://github.com/nefarius/ViGEmBus) framework.
-As such, it emulates true physical DS4 and X360 gamepads.
+## Linux implementation details
 
-On Linux, `vgamepad` currently relies on `libevdev`.
-It emulates a subset of the X360 and DS4 capabilities in `evdev` by managing a virtual `uinput` device.
+On Windows, `vgamepad` wraps Nefarius' [Virtual Gamepad Emulation](https://github.com/nefarius/ViGEmBus) framework.
 
-While we are trying to make this emulation close to the real thing, we are not quite there yet.
-If you know how to advance toward this goal, your contribution will be **very appreciated** :heart_eyes:
+On Linux, `vgamepad` uses `libevdev` to create virtual `uinput` devices. The Linux backend supports the same API as Windows:
 
-For now, most basic `vgamepad` calls work on Linux, but you should not expect your application to react exactly as if an actual X360 / DS4 gamepad were connected to your machine.
-Nevertheless, the corresponding `evdev` event should be similar.
+### Supported features
+- All X360 buttons including the **Guide/Mode button** (`XUSB_GAMEPAD_GUIDE`)
+- All DS4 buttons including **touchpad press** (`DS4_SPECIAL_BUTTON_TOUCHPAD`)
+- DS4 **trigger buttons** (`DS4_BUTTON_TRIGGER_LEFT` / `DS4_BUTTON_TRIGGER_RIGHT`) mapped to `BTN_TL2` / `BTN_TR2`
+- Joysticks, triggers, and directional pad (hat)
+- **Force feedback / Rumble** via `register_notification()` and `unregister_notification()`
+- **Extended reports** via `update_extended_report()` (DS4)
+- `reset()`, `get_vid()`, `get_pid()`, `set_vid()`, `set_pid()`, `get_type()`, `get_index()`
 
-**What you should know:**
-- Detected buttons, ordering and axes directions are typically different from Windows (depending on your app)
-- Force feedback / LEDS are not implemented on Linux yet
-- DS4 touchpad / motion sensor are not implemented on Linux yet (no extended report)
-- Real DS4 gamepads fire a button event when you press the triggers (on top of the axis event), this button event is not implemented in `vgamepad` at the moment
-- The X360 "guide" (mode) button is not implemented in `vgamepad` at the moment
+### Notes
+- Detected button ordering and axis directions may differ from Windows depending on the consuming application (e.g. pygame maps button indices differently)
+- LED number in the rumble callback is always 0 on Linux
+- Force feedback notifications are delivered via a background thread that reads FF events from the uinput device
+- DS4 motion sensor data (gyro/accel) and touchpad coordinates from extended reports are not emitted as evdev events; only the standard gamepad fields are forwarded

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[metadata]
-description_file = README.md
-license = MIT

--- a/setup.py
+++ b/setup.py
@@ -1,95 +1,77 @@
-from setuptools import setup, find_packages
-import platform
-from pathlib import Path
+"""
+Windows-only post-install hook: detect and install the ViGEmBus driver.
+
+All project metadata lives in pyproject.toml.  This file is only needed
+because the ViGEmBus MSI must be run as a side-effect of `pip install`.
+On Linux this file is a no-op.
+"""
+
+from __future__ import annotations
+
 import os
+import platform
 import subprocess
 import sys
 import warnings
+from pathlib import Path
 
-
-assert platform.system() in ('Windows', 'Linux'), "vgamepad is only supported on Windows and Linux."
-
+from setuptools import setup
 
 VIGEMBUS_VERSION = "1.17.333.0"
-VGAMEPAD_VERSION = "0.1.3"
+
+_is_windows = platform.system() == "Windows"
 
 
-archstr = platform.machine()
-if archstr.endswith('64'):
-    arch = "x64"
-elif archstr.endswith('86'):
-    arch = "x86"
-else:
-    if platform.architecture()[0] == "64bit":
-        arch = "x64"
-    else:
-        arch = "x86"
-    warnings.warn(f"vgamepad could not determine your system architecture: \
-                  the vigembus installer will default to {arch}. If this is not your machine architecture, \
-                  please cancel the upcoming vigembus installation and install vigembus manually from \
-                  https://github.com/ViGEm/ViGEmBus/releases/tag/setup-v1.17.333")
+def _detect_arch() -> str:
+    machine = platform.machine()
+    if machine.endswith("64"):
+        return "x64"
+    if machine.endswith("86"):
+        return "x86"
+    arch = "x64" if platform.architecture()[0] == "64bit" else "x86"
+    warnings.warn(
+        f"Could not determine system architecture from '{machine}'; "
+        f"defaulting to {arch}.  If this is wrong, cancel the upcoming "
+        f"ViGEmBus installation and install it manually from "
+        f"https://github.com/ViGEm/ViGEmBus/releases/tag/setup-v{VIGEMBUS_VERSION}",
+        stacklevel=2,
+    )
+    return arch
 
-pathMsi = Path(__file__).parent.absolute() / "vgamepad" / "win" / "vigem" / "install" / arch / ("ViGEmBusSetup_" + arch + ".msi")
 
-is_windows = platform.system() == 'Windows'
+def _install_vigembus() -> None:
+    if not _is_windows:
+        return
+    if os.environ.get("VGAMEPAD_SKIP_VIGEMBUS_INSTALL", "").lower() == "true":
+        return
+    if len(sys.argv) > 1 and sys.argv[1] in {"egg_info", "sdist"}:
+        return
 
-if is_windows:
-    # Try to detect vigembus:
     try:
-        registry_str = subprocess.check_output(
-            ['reg', 'query', r'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall', '/s'], text=True).lower()
-        j = registry_str.find('nefarius virtual gamepad emulation bus driver')
-        if j > 0:
-            vigem_installed = True
-            i = registry_str[:j].rfind('displayversion')
-            if i != -1:
-                vigem_version = registry_str[i:j].split()[2]
-                if vigem_version != VIGEMBUS_VERSION:
-                    warnings.warn(f"found vigembus version {vigem_version} on your system. Expected {VIGEMBUS_VERSION}.")
-        else:
-            vigem_installed = False
-    except Exception as e:
-        vigem_installed = False
-        warnings.warn(f"vgamepad could not run the vigembus detection on your system, \
-                      an exception has been caught while trying: \n{e}")
+        reg_output = subprocess.check_output(
+            ["reg", "query", r"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", "/s"],
+            text=True,
+        ).lower()
+        marker = "nefarius virtual gamepad emulation bus driver"
+        idx = reg_output.find(marker)
+        if idx > 0:
+            ver_idx = reg_output[:idx].rfind("displayversion")
+            if ver_idx != -1:
+                found_ver = reg_output[ver_idx:idx].split()[2]
+                if found_ver != VIGEMBUS_VERSION:
+                    warnings.warn(
+                        f"Found ViGEmBus {found_ver}; expected {VIGEMBUS_VERSION}.",
+                        stacklevel=2,
+                    )
+            return  # already installed
+    except Exception as exc:
+        warnings.warn(f"ViGEmBus detection failed: {exc}", stacklevel=2)
 
-    # Prompt installation of the ViGEmBus driver (blocking call)
-    if sys.argv[1] != 'egg_info' and sys.argv[1] != 'sdist':
-        if not vigem_installed and not os.environ.get('VGAMEPAD_SKIP_VIGEMBUS_INSTALL', 'false') == 'true':
-            subprocess.call(['msiexec', '/i', '%s' % str(pathMsi)], shell=True)
+    arch = _detect_arch()
+    msi = Path(__file__).parent / "vgamepad" / "win" / "vigem" / "install" / arch / f"ViGEmBusSetup_{arch}.msi"
+    subprocess.call(["msiexec", "/i", str(msi)], shell=True)
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
 
-setup(
-    name='vgamepad',
-    packages=[package for package in find_packages()],
-    version=VGAMEPAD_VERSION,
-    license='MIT',
-    description='Virtual XBox360 and DualShock4 gamepads in python',
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author='Yann Bouteiller',
-    url='https://github.com/yannbouteiller/vgamepad',
-    download_url=f'https://github.com/yannbouteiller/vgamepad/archive/refs/tags/v{VGAMEPAD_VERSION}.tar.gz',
-    keywords=['virtual', 'gamepad', 'python', 'xbox', 'dualshock', 'controller', 'emulator'],
-    install_requires=['libevdev~=0.11'] if not is_windows else [],
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: Science/Research',
-        'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python',
-        'Topic :: Software Development :: Build Tools',
-        'Topic :: Games/Entertainment',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-    ],
-    package_data={'vgamepad': [
-        'win/vigem/client/x64/ViGEmClient.dll',
-        'win/vigem/client/x86/ViGEmClient.dll',
-        'win/vigem/install/x64/ViGEmBusSetup_x64.msi',
-        'win/vigem/install/x86/ViGEmBusSetup_x86.msi',
-    ] if is_windows else []}
-)
+_install_vigembus()
+
+setup()

--- a/test/test_VDS4Gamepad.py
+++ b/test/test_VDS4Gamepad.py
@@ -1,24 +1,21 @@
 from os import environ
-environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 
+environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
+
+import platform
 import time
 import unittest
-import platform
-
-import vgamepad as vg
-
-# We use pygame to test vgamepad.
-# pygame must be installed to run these tests.
-# Furthermore, these tests can only run with a display (pygame requirement).
 
 import pygame
+from loguru import logger
 
+import vgamepad as vg
 
 WAIT_S = 0.1
 SYSTEM = platform.system()
 
 DS4_NAME = "PS4 Controller" if SYSTEM == "Windows" else "Sony Interactive Entertainment Wireless Controller"
-DS4_NB_BUTTONS = 16 if SYSTEM == "Windows" else 13
+DS4_NB_BUTTONS = 16 if SYSTEM == "Windows" else 14
 DS4_NB_HATS = 0 if SYSTEM == "Windows" else 1
 
 DS4_LEFT_TRIGGER = 4 if SYSTEM == "Windows" else 2
@@ -27,59 +24,71 @@ DS4_LEFT_JOYSTICK = (0, 1)
 DS4_RIGHT_JOYSTICK = (2, 3) if SYSTEM == "Windows" else (3, 4)
 DS4_DIRECTIONAL_PAD = (11, 12, 13, 14) if SYSTEM == "Windows" else None
 
-DS4_TEST_BUTTONS = [
-    (vg.DS4_BUTTONS.DS4_BUTTON_CROSS, 0),
-    (vg.DS4_BUTTONS.DS4_BUTTON_CIRCLE, 1),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SQUARE, 2),
-    (vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE, 3),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SHARE, 4),
-    (vg.DS4_BUTTONS.DS4_BUTTON_OPTIONS, 6),
-    (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_LEFT, 7),
-    (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT, 8),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_LEFT, 9),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_RIGHT, 10),
-    ] if SYSTEM == "Windows" else [
-    (vg.DS4_BUTTONS.DS4_BUTTON_CROSS, 0),
-    (vg.DS4_BUTTONS.DS4_BUTTON_CIRCLE, 1),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SQUARE, 3),
-    (vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE, 2),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SHARE, 9),
-    (vg.DS4_BUTTONS.DS4_BUTTON_OPTIONS, 8),
-    (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_LEFT, 11),
-    (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT, 12),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_LEFT, 4),
-    (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_RIGHT, 5),
+DS4_TEST_BUTTONS = (
+    [
+        (vg.DS4_BUTTONS.DS4_BUTTON_CROSS, 0),
+        (vg.DS4_BUTTONS.DS4_BUTTON_CIRCLE, 1),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SQUARE, 2),
+        (vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE, 3),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SHARE, 4),
+        (vg.DS4_BUTTONS.DS4_BUTTON_OPTIONS, 6),
+        (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_LEFT, 7),
+        (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT, 8),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_LEFT, 9),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_RIGHT, 10),
     ]
+    if SYSTEM == "Windows"
+    else [
+        (vg.DS4_BUTTONS.DS4_BUTTON_CROSS, 0),
+        (vg.DS4_BUTTONS.DS4_BUTTON_CIRCLE, 1),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SQUARE, 3),
+        (vg.DS4_BUTTONS.DS4_BUTTON_TRIANGLE, 2),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SHARE, 9),
+        (vg.DS4_BUTTONS.DS4_BUTTON_OPTIONS, 8),
+        (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_LEFT, 11),
+        (vg.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT, 12),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_LEFT, 4),
+        (vg.DS4_BUTTONS.DS4_BUTTON_SHOULDER_RIGHT, 5),
+    ]
+)
 
-DS4_TEST_SPECIAL_BUTTONS = [
-    (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS, 5),
-    (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD, 15),
-    ] if SYSTEM == "Windows" else [
-    (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS, 10),
-    # (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD, 15),  # not implemented on Linux
+DS4_TEST_SPECIAL_BUTTONS = (
+    [
+        (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS, 5),
+        (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD, 15),
     ]
+    if SYSTEM == "Windows"
+    else [
+        (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS, 10),
+        (vg.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD, 13),
+    ]
+)
 
-DS4_TEST_DIRECTIONAL_PAD = [  # On Windows, pygame detects the directional pad as 4 buttons
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE, (0, 0, 0, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST, (1, 0, 1, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_WEST, (0, 0, 1, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHWEST, (0, 1, 1, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTH, (0, 1, 0, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHEAST, (0, 1, 0, 1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_EAST, (0, 0, 0, 1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHEAST, (1, 0, 0, 1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTH, (1, 0, 0, 0)),
-    ] if SYSTEM == "Windows" else [  # FIXME: On Linux, pygame detects the directional pad as a hat with 2 axes
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE, (0, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST, (-1, 1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_WEST, (-1, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHWEST, (-1, -1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTH, (0, -1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHEAST, (1, -1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_EAST, (1, 0)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHEAST, (1, 1)),
-    (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTH, (0, 1)),
+DS4_TEST_DIRECTIONAL_PAD = (
+    [
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE, (0, 0, 0, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST, (1, 0, 1, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_WEST, (0, 0, 1, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHWEST, (0, 1, 1, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTH, (0, 1, 0, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHEAST, (0, 1, 0, 1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_EAST, (0, 0, 0, 1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHEAST, (1, 0, 0, 1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTH, (1, 0, 0, 0)),
     ]
+    if SYSTEM == "Windows"
+    else [
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE, (0, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST, (-1, 1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_WEST, (-1, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHWEST, (-1, -1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTH, (0, -1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHEAST, (1, -1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_EAST, (1, 0)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHEAST, (1, 1)),
+        (vg.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTH, (0, 1)),
+    ]
+)
 
 DS4_TEST_TRIGGER_INT = [
     (0, -1.0),
@@ -89,13 +98,13 @@ DS4_TEST_TRIGGER_INT = [
     (127, 0.0),
     (191, 0.5),
     (255, 1.0),
-    ]
+]
 
 DS4_TEST_TRIGGER_FLOAT = [
     (0.0, -1.0),
     (0.5, 0.0),
     (1.0, 1.0),
-    ]
+]
 
 DS4_TEST_JOYSTICK_INT = [
     ((0, 127), (-1.0, 0.0)),
@@ -103,7 +112,7 @@ DS4_TEST_JOYSTICK_INT = [
     ((127, 0), (0.0, -1.0)),
     ((191, 255), (0.5, 1.0)),
     ((255, 191), (1.0, 0.5)),
-    ]
+]
 
 DS4_TEST_JOYSTICK_FLOAT = [
     ((-1.0, 0.0), (-1.0, 0.0)),
@@ -111,21 +120,18 @@ DS4_TEST_JOYSTICK_FLOAT = [
     ((0.0, -1.0), (0.0, -1.0)),
     ((0.5, 1.0), (0.5, 1.0)),
     ((1.0, 0.5), (1.0, 0.5)),
-    ]
+]
 
 
 class TestVDS4Gamepad(unittest.TestCase):
-
-    def setUp(self):
-        print(f"Setting up VDS4Gamepad")
+    def setUp(self) -> None:
+        logger.info("Setting up VDS4Gamepad")
 
         self.g = vg.VDS4Gamepad()
-        # press a button to wake the device up
         self.g.press_button(button=vg.DS4_BUTTONS.DS4_BUTTON_CROSS)
         self.g.update()
         time.sleep(WAIT_S)
         self.g.release_button(button=vg.DS4_BUTTONS.DS4_BUTTON_CROSS)
-        # wake axes up
         self.g.left_joystick_float(x_value_float=0.3, y_value_float=-0.3)
         self.g.right_joystick_float(x_value_float=-0.3, y_value_float=0.3)
         self.g.left_trigger_float(value_float=0.3)
@@ -142,82 +148,53 @@ class TestVDS4Gamepad(unittest.TestCase):
         pygame.init()
         self.joysticks = [pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())]
 
-    def test_all(self):
-        self.assertTrue(SYSTEM in ("Windows", "Linux"))
-
-        # Check that only one gamepad is connected:
-        self.assertTrue(len(self.joysticks) == 1)
+    def test_all(self) -> None:
+        self.assertIn(SYSTEM, ("Windows", "Linux"))
+        self.assertEqual(len(self.joysticks), 1)
         j = self.joysticks[0]
 
-        # Check that gamepad properties are correct:
-        name = j.get_name()
-        nb_axes = j.get_numaxes()
-        nb_balls = j.get_numballs()
+        self.assertEqual(j.get_name(), DS4_NAME)
+        self.assertEqual(j.get_numaxes(), 6)
+        self.assertEqual(j.get_numballs(), 0)
+        self.assertEqual(j.get_numbuttons(), DS4_NB_BUTTONS)
+        self.assertEqual(j.get_numhats(), DS4_NB_HATS)
+
         nb_buttons = j.get_numbuttons()
-        nb_hats = j.get_numhats()
-        self.assertTrue(name == DS4_NAME)
-        self.assertEqual(nb_axes, 6)
-        self.assertEqual(nb_balls, 0)
-        self.assertEqual(nb_buttons, DS4_NB_BUTTONS)
-        self.assertEqual(nb_hats, DS4_NB_HATS)
 
-        # Check that buttons are correct:
-
-        tested_buttons = DS4_TEST_BUTTONS
-
-        for v_button, j_button in tested_buttons:
+        for v_button, j_button in DS4_TEST_BUTTONS:
             self.g.press_button(button=v_button)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_button, j_button}")
-
+            logger.debug("Testing button: {} -> {}", v_button, j_button)
             self.assertTrue(j.get_button(j_button))
-
             for i in range(nb_buttons):
                 if i != j_button:
                     self.assertFalse(j.get_button(i))
-
             self.g.release_button(button=v_button)
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that special buttons are correct:
-
-        tested_special_buttons = DS4_TEST_SPECIAL_BUTTONS
-
-        for v_button, j_button in tested_special_buttons:
+        for v_button, j_button in DS4_TEST_SPECIAL_BUTTONS:
             self.g.press_special_button(special_button=v_button)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_button, j_button}")
-
+            logger.debug("Testing special button: {} -> {}", v_button, j_button)
             self.assertTrue(j.get_button(j_button))
-
             for i in range(nb_buttons):
                 if i != j_button:
                     self.assertFalse(j.get_button(i))
-
             self.g.release_special_button(special_button=v_button)
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that directional pad is correct:
-
-        tested_values = DS4_TEST_DIRECTIONAL_PAD
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_DIRECTIONAL_PAD:
             self.g.directional_pad(direction=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-
-            print(f"Testing: {v_value, j_value}")
-
+            logger.debug("Testing dpad: {} -> {}", v_value, j_value)
             if SYSTEM == "Windows":
                 self.assertEqual(j.get_button(DS4_DIRECTIONAL_PAD[0]), j_value[0])
                 self.assertEqual(j.get_button(DS4_DIRECTIONAL_PAD[1]), j_value[1])
@@ -225,155 +202,117 @@ class TestVDS4Gamepad(unittest.TestCase):
                 self.assertEqual(j.get_button(DS4_DIRECTIONAL_PAD[3]), j_value[3])
             else:
                 self.assertEqual(j.get_hat(0), j_value)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that triggers are correct (absolute):
-
-        tested_values = DS4_TEST_TRIGGER_INT
-
-        # Left trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_TRIGGER_INT:
             self.g.left_trigger(value=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left trigger int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_LEFT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_TRIGGER_INT:
             self.g.right_trigger(value=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right trigger int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_RIGHT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that triggers are correct (float):
-
-        tested_values = DS4_TEST_TRIGGER_FLOAT
-
-        # Left trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_TRIGGER_FLOAT:
             self.g.left_trigger_float(value_float=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left trigger float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_LEFT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_TRIGGER_FLOAT:
             self.g.right_trigger_float(value_float=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right trigger float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_RIGHT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that joysticks are correct (absolute):
-
-        tested_values = DS4_TEST_JOYSTICK_INT
-
-        # Left joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_JOYSTICK_INT:
             self.g.left_joystick(x_value=v_value[0], y_value=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left joystick int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_LEFT_JOYSTICK[0]), j_value[0], delta=0.01)
             self.assertAlmostEqual(j.get_axis(DS4_LEFT_JOYSTICK[1]), j_value[1], delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_JOYSTICK_INT:
             self.g.right_joystick(x_value=v_value[0], y_value=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right joystick int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_RIGHT_JOYSTICK[0]), j_value[0], delta=0.01)
             self.assertAlmostEqual(j.get_axis(DS4_RIGHT_JOYSTICK[1]), j_value[1], delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that joysticks are correct (float):
-
-        tested_values = DS4_TEST_JOYSTICK_FLOAT
-
-        # Left joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_JOYSTICK_FLOAT:
             self.g.left_joystick_float(x_value_float=v_value[0], y_value_float=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left joystick float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_LEFT_JOYSTICK[0]), j_value[0], delta=0.01)
             self.assertAlmostEqual(j.get_axis(DS4_LEFT_JOYSTICK[1]), j_value[1], delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in DS4_TEST_JOYSTICK_FLOAT:
             self.g.right_joystick_float(x_value_float=v_value[0], y_value_float=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right joystick float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(DS4_RIGHT_JOYSTICK[0]), j_value[0], delta=0.01)
             self.assertAlmostEqual(j.get_axis(DS4_RIGHT_JOYSTICK[1]), j_value[1], delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-    def tearDown(self):
+    def test_notification(self) -> None:
+        """Test that register/unregister notification work without error."""
+        received: list = []
+
+        def my_callback(client, target, large_motor, small_motor, led_number, user_data):  # type: ignore[no-untyped-def]
+            received.append((large_motor, small_motor, led_number))
+
+        self.g.register_notification(callback_function=my_callback)
+        time.sleep(0.2)
+        self.g.unregister_notification()
+
+    def tearDown(self) -> None:
         del self.g
         pygame.quit()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/test_VX360Gamepad.py
+++ b/test/test_VX360Gamepad.py
@@ -1,18 +1,15 @@
 from os import environ
-environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 
+environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
+
+import platform
 import time
 import unittest
-import platform
-
-import vgamepad as vg
-
-# We use pygame to test vgamepad.
-# pygame must be installed to run these tests.
-# Furthermore, these tests can only run with a display (pygame requirement).
 
 import pygame
+from loguru import logger
 
+import vgamepad as vg
 
 WAIT_S = 0.1
 SYSTEM = platform.system()
@@ -33,15 +30,15 @@ X360_TEST_BUTTONS = [
     (vg.XUSB_BUTTON.XUSB_GAMEPAD_START, 7),
     (vg.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_THUMB, 8),
     (vg.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_THUMB, 9),
-    # (vg.XUSB_BUTTON.XUSB_GAMEPAD_GUIDE, 10),  # Does not exist on Linux
-    ]
+    (vg.XUSB_BUTTON.XUSB_GAMEPAD_GUIDE, 10),
+]
 
 X360_TEST_HAT = [
     (vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_UP, (0, 1)),
     (vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_DOWN, (0, -1)),
     (vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_LEFT, (-1, 0)),
-    (vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_RIGHT, (1, 0))
-    ]
+    (vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_RIGHT, (1, 0)),
+]
 
 X360_TEST_TRIGGER_INT = [
     (0, -1.0),
@@ -51,55 +48,60 @@ X360_TEST_TRIGGER_INT = [
     (127, 0.0),
     (191, 0.5),
     (255, 1.0),
-    ]
+]
 
 X360_TEST_TRIGGER_FLOAT = [
     (0.0, -1.0),
     (0.5, 0.0),
     (1.0, 1.0),
-    ]
+]
 
-X360_TEST_JOYSTICK_INT = [
-    ((-32768, 0), (-1.0, 0.0)),
-    ((-16384, 16383), (-0.5, -0.5)),
-    ((0, 32767), (0.0, -1.0)),
-    ((16383, -32768), (0.5, 1.0)),
-    ((32767, -16384), (1.0, 0.5)),
-    ] if SYSTEM == "Windows" else [
-    ((-32768, 0), (-1.0, 0.0)),
-    ((-16384, 16383), (-0.5, 0.5)),
-    ((0, 32767), (0.0, 1.0)),
-    ((16383, -32768), (0.5, -1.0)),
-    ((32767, -16384), (1.0, -0.5)),
+X360_TEST_JOYSTICK_INT = (
+    [
+        ((-32768, 0), (-1.0, 0.0)),
+        ((-16384, 16383), (-0.5, -0.5)),
+        ((0, 32767), (0.0, -1.0)),
+        ((16383, -32768), (0.5, 1.0)),
+        ((32767, -16384), (1.0, 0.5)),
     ]
+    if SYSTEM == "Windows"
+    else [
+        ((-32768, 0), (-1.0, 0.0)),
+        ((-16384, 16383), (-0.5, 0.5)),
+        ((0, 32767), (0.0, 1.0)),
+        ((16383, -32768), (0.5, -1.0)),
+        ((32767, -16384), (1.0, -0.5)),
+    ]
+)
 
-X360_TEST_JOYSTICK_FLOAT = [
-    ((-1.0, 0.0), (-1.0, 0.0)),
-    ((-0.5, 0.5), (-0.5, -0.5)),
-    ((0.0, 1.0), (0.0, -1.0)),
-    ((0.5, -1.0), (0.5, 1.0)),
-    ((1.0, -0.5), (1.0, 0.5)),
-    ] if SYSTEM == "Windows" else [
-    ((-1.0, 0.0), (-1.0, 0.0)),
-    ((-0.5, 0.5), (-0.5, 0.5)),
-    ((0.0, 1.0), (0.0, 1.0)),
-    ((0.5, -1.0), (0.5, -1.0)),
-    ((1.0, -0.5), (1.0, -0.5)),
+X360_TEST_JOYSTICK_FLOAT = (
+    [
+        ((-1.0, 0.0), (-1.0, 0.0)),
+        ((-0.5, 0.5), (-0.5, -0.5)),
+        ((0.0, 1.0), (0.0, -1.0)),
+        ((0.5, -1.0), (0.5, 1.0)),
+        ((1.0, -0.5), (1.0, 0.5)),
     ]
+    if SYSTEM == "Windows"
+    else [
+        ((-1.0, 0.0), (-1.0, 0.0)),
+        ((-0.5, 0.5), (-0.5, 0.5)),
+        ((0.0, 1.0), (0.0, 1.0)),
+        ((0.5, -1.0), (0.5, -1.0)),
+        ((1.0, -0.5), (1.0, -0.5)),
+    ]
+)
 
 
 class TestVX360Gamepad(unittest.TestCase):
-
-    def setUp(self):
-        print(f"Setting up VX360Gamepad")
+    def setUp(self) -> None:
+        logger.info("Setting up VX360Gamepad")
 
         self.g = vg.VX360Gamepad()
-        # press a button to wake the device up
         self.g.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
         self.g.update()
         time.sleep(WAIT_S)
         self.g.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_A)
-        # wake axes up
         self.g.left_joystick_float(x_value_float=0.3, y_value_float=-0.3)
         self.g.right_joystick_float(x_value_float=-0.3, y_value_float=0.3)
         self.g.left_trigger_float(value_float=0.3)
@@ -116,207 +118,151 @@ class TestVX360Gamepad(unittest.TestCase):
         pygame.init()
         self.joysticks = [pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())]
 
-    def test_all(self):
-        self.assertTrue(SYSTEM in ("Windows", "Linux"))
-
-        # Check that only one gamepad is connected:
-        self.assertTrue(len(self.joysticks) == 1)
+    def test_all(self) -> None:
+        self.assertIn(SYSTEM, ("Windows", "Linux"))
+        self.assertEqual(len(self.joysticks), 1)
         j = self.joysticks[0]
 
-        # Check that gamepad properties are correct:
-        name = j.get_name()
-        nb_axes = j.get_numaxes()
-        nb_balls = j.get_numballs()
+        self.assertEqual(j.get_name(), "Xbox 360 Controller")
+        self.assertEqual(j.get_numaxes(), 6)
+        self.assertEqual(j.get_numballs(), 0)
+        self.assertEqual(j.get_numbuttons(), 11)
+        self.assertEqual(j.get_numhats(), 1)
+
         nb_buttons = j.get_numbuttons()
-        nb_hats = j.get_numhats()
-        self.assertTrue(name == "Xbox 360 Controller")
-        self.assertEqual(nb_axes, 6)
-        self.assertEqual(nb_balls, 0)
-        self.assertEqual(nb_buttons, 11 if SYSTEM == "Windows" else 10)  # No GUIDE button on Linux
-        self.assertEqual(nb_hats, 1)
 
-        # Check that buttons are correct:
-
-        tested_buttons = X360_TEST_BUTTONS
-
-        for v_button, j_button in tested_buttons:
+        for v_button, j_button in X360_TEST_BUTTONS:
             self.g.press_button(button=v_button)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_button, j_button}")
+            logger.debug("Testing button: {} -> {}", v_button, j_button)
             self.assertTrue(j.get_button(j_button))
-
             for i in range(nb_buttons):
                 if i != j_button:
                     self.assertFalse(j.get_button(i))
-
             self.g.release_button(button=v_button)
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that hat is correct:
-
-        tested_hat_buttons = X360_TEST_HAT
-
-        for v_hat_button, j_hat_button in tested_hat_buttons:
+        for v_hat_button, j_hat_button in X360_TEST_HAT:
             self.g.press_button(button=v_hat_button)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_hat_button, j_hat_button}")
+            logger.debug("Testing hat: {} -> {}", v_hat_button, j_hat_button)
             self.assertEqual(j.get_hat(0), j_hat_button)
-
             self.g.release_button(button=v_hat_button)
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that triggers are correct (absolute):
-
-        tested_values = X360_TEST_TRIGGER_INT
-
-        # Left trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_TRIGGER_INT:
             self.g.left_trigger(value=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left trigger int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_LEFT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_TRIGGER_INT:
             self.g.right_trigger(value=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right trigger int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_RIGHT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that triggers are correct (float):
-
-        tested_values = X360_TEST_TRIGGER_FLOAT
-
-        # Left trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_TRIGGER_FLOAT:
             self.g.left_trigger_float(value_float=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left trigger float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_LEFT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right trigger:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_TRIGGER_FLOAT:
             self.g.right_trigger_float(value_float=v_value)
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right trigger float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_RIGHT_TRIGGER), j_value, delta=0.01)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that joysticks are correct (absolute):
-
-        tested_values = X360_TEST_JOYSTICK_INT
-
-        # Left joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_JOYSTICK_INT:
             self.g.left_joystick(x_value=v_value[0], y_value=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left joystick int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_LEFT_JOYSTICK[0]), j_value[0], delta=0.001)
             self.assertAlmostEqual(j.get_axis(X360_LEFT_JOYSTICK[1]), j_value[1], delta=0.001)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_JOYSTICK_INT:
             self.g.right_joystick(x_value=v_value[0], y_value=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right joystick int: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_RIGHT_JOYSTICK[0]), j_value[0], delta=0.001)
             self.assertAlmostEqual(j.get_axis(X360_RIGHT_JOYSTICK[1]), j_value[1], delta=0.001)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Check that joysticks are correct (float):
-
-        tested_values = X360_TEST_JOYSTICK_FLOAT
-
-        # Left joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_JOYSTICK_FLOAT:
             self.g.left_joystick_float(x_value_float=v_value[0], y_value_float=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing left joystick float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_LEFT_JOYSTICK[0]), j_value[0], delta=0.001)
             self.assertAlmostEqual(j.get_axis(X360_LEFT_JOYSTICK[1]), j_value[1], delta=0.001)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-        # Right joystick:
-
-        for v_value, j_value in tested_values:
+        for v_value, j_value in X360_TEST_JOYSTICK_FLOAT:
             self.g.right_joystick_float(x_value_float=v_value[0], y_value_float=v_value[1])
             self.g.update()
             time.sleep(WAIT_S)
-
             _ = pygame.event.get()
-            print(f"Testing: {v_value, j_value}")
+            logger.debug("Testing right joystick float: {} -> {}", v_value, j_value)
             self.assertAlmostEqual(j.get_axis(X360_RIGHT_JOYSTICK[0]), j_value[0], delta=0.001)
             self.assertAlmostEqual(j.get_axis(X360_RIGHT_JOYSTICK[1]), j_value[1], delta=0.001)
-
             self.g.reset()
             self.g.update()
             time.sleep(WAIT_S)
 
-    def tearDown(self):
+    def test_notification(self) -> None:
+        """Test that register/unregister notification work without error."""
+        received: list = []
+
+        def my_callback(client, target, large_motor, small_motor, led_number, user_data):  # type: ignore[no-untyped-def]
+            received.append((large_motor, small_motor, led_number))
+
+        self.g.register_notification(callback_function=my_callback)
+        time.sleep(0.2)
+        self.g.unregister_notification()
+
+    def tearDown(self) -> None:
         del self.g
         pygame.quit()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/vgamepad/__init__.py
+++ b/vgamepad/__init__.py
@@ -1,7 +1,44 @@
-import platform
-from vgamepad.win.vigem_commons import VIGEM_TARGET_TYPE, XUSB_BUTTON, DS4_BUTTONS, DS4_SPECIAL_BUTTONS, DS4_DPAD_DIRECTIONS
+"""vgamepad - Virtual Xbox 360 and DualShock 4 gamepads in Python."""
 
-if platform.system() == 'Windows':
-    from vgamepad.win.virtual_gamepad import VX360Gamepad, VDS4Gamepad
-else:  # Linux
-    from vgamepad.lin.virtual_gamepad import VX360Gamepad, VDS4Gamepad
+from __future__ import annotations
+
+import platform
+
+from loguru import logger
+
+from vgamepad.win.vigem_commons import (
+    DS4_BUTTONS,
+    DS4_DPAD_DIRECTIONS,
+    DS4_REPORT,
+    DS4_REPORT_EX,
+    DS4_REPORT_INIT,
+    DS4_SET_DPAD,
+    DS4_SPECIAL_BUTTONS,
+    VIGEM_TARGET_TYPE,
+    XUSB_BUTTON,
+    XUSB_REPORT,
+)
+
+__version__ = "0.1.3"
+
+logger.disable("vgamepad")
+
+if platform.system() == "Windows":
+    from vgamepad.win.virtual_gamepad import VDS4Gamepad, VX360Gamepad
+else:
+    from vgamepad.lin.virtual_gamepad import VDS4Gamepad, VX360Gamepad
+
+__all__ = [
+    "DS4_BUTTONS",
+    "DS4_DPAD_DIRECTIONS",
+    "DS4_REPORT",
+    "DS4_REPORT_EX",
+    "DS4_REPORT_INIT",
+    "DS4_SET_DPAD",
+    "DS4_SPECIAL_BUTTONS",
+    "VIGEM_TARGET_TYPE",
+    "XUSB_BUTTON",
+    "XUSB_REPORT",
+    "VDS4Gamepad",
+    "VX360Gamepad",
+]

--- a/vgamepad/lin/virtual_gamepad.py
+++ b/vgamepad/lin/virtual_gamepad.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 import contextlib
 import ctypes
 import fcntl
-import os
 import select
 import struct
+import sys
 import threading
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from inspect import signature
 from typing import Any, ClassVar
 
 import libevdev
-from loguru import logger
+from loguru import logger  # Logging is off by default. It can be enabled in __init__.py
 
 import vgamepad.win.vigem_commons as vcom
 
@@ -78,13 +79,13 @@ class _FFErase(ctypes.Structure):
 
 
 def _dummy_callback(
-    client: Any,
-    target: Any,
-    large_motor: int,
-    small_motor: int,
-    led_number: int,
-    user_data: Any,
-) -> None:
+        client,
+        target,
+        large_motor,
+        small_motor,
+        led_number,
+        user_data,
+):
     pass
 
 
@@ -137,77 +138,6 @@ class VGamepad(ABC):
         """Return the type of the object (bus type)."""
         return self.device.id.bustype
 
-    def register_notification(self, callback_function: Callable[..., Any]) -> None:
-        """Register a callback for force-feedback notifications.
-
-        On Linux force feedback is implemented by reading ``FF_RUMBLE``
-        events from the uinput device.  The callback receives the same
-        signature as Windows:
-
-            ``callback(client, target, large_motor, small_motor, led_number, user_data)``
-
-        ``large_motor`` and ``small_motor`` are scaled to 0-255 from the
-        kernel's 0-65535 range.
-        """
-        if signature(callback_function) != signature(_dummy_callback):
-            raise TypeError(
-                f"Expected callback signature: {signature(_dummy_callback)}, "
-                f"got: {signature(callback_function)}"
-            )
-
-        self._ff_callback = callback_function
-
-        if self._ff_thread is not None:
-            return
-
-        devnode = self.uinput.devnode
-        if devnode is None:
-            return
-
-        self._ff_stop.clear()
-        self._ff_thread = threading.Thread(
-            target=self._ff_reader_loop,
-            args=(devnode,),
-            daemon=True,
-        )
-        self._ff_thread.start()
-
-    def _ff_reader_loop(self, devnode: str) -> None:
-        """Background thread: reads EV_FF / EV_UINPUT events and dispatches rumble callbacks."""
-        try:
-            fd = os.open(devnode, os.O_RDWR | os.O_NONBLOCK)
-        except OSError:
-            logger.warning("Could not open {} for force-feedback reading", devnode)
-            return
-        try:
-            while not self._ff_stop.is_set():
-                ready, _, _ = select.select([fd], [], [], 0.1)
-                if not ready:
-                    continue
-                try:
-                    data = os.read(fd, 24)
-                except OSError:
-                    continue
-                if len(data) < 24:
-                    continue
-                _sec, _usec, ev_type, ev_code, ev_value = struct.unpack("llHHi", data)
-                if ev_type == _EV_FF and ev_code in self._ff_effects:
-                    strong, weak = self._ff_effects[ev_code]
-                    large_motor = (strong * 255) // 65535 if strong else 0
-                    small_motor = (weak * 255) // 65535 if weak else 0
-                    if self._ff_callback:
-                        try:
-                            self._ff_callback(None, None, large_motor, small_motor, 0, None)
-                        except Exception:
-                            logger.opt(exception=True).debug("FF callback raised")
-                elif ev_type == _EV_UINPUT:
-                    if ev_code == _UI_FF_UPLOAD:
-                        self._handle_ff_upload(fd, ev_value)
-                    elif ev_code == _UI_FF_ERASE:
-                        self._handle_ff_erase(fd, ev_value)
-        finally:
-            os.close(fd)
-
     def _handle_ff_upload(self, fd: int, request_id: int) -> None:
         """Handle a UI_FF_UPLOAD request from the kernel."""
         upload = _FFUpload()
@@ -241,24 +171,100 @@ class VGamepad(ABC):
         with contextlib.suppress(OSError):
             fcntl.ioctl(fd, UI_END_FF_ERASE, erase)
 
-    def unregister_notification(self) -> None:
-        """Unregister a previously registered callback function."""
-        self._ff_callback = None
-        self._ff_stop.set()
-        if self._ff_thread is not None:
-            self._ff_thread.join(timeout=2.0)
-            self._ff_thread = None
-        self._ff_effects.clear()
+    def get_raw_uinput_fd(self) -> int:
+        """Retrieves fd from /dev/uinput, bypassing libevdev."""
+        for fd in os.listdir("/proc/self/fd"):
+            try:
+                if os.readlink(f"/proc/self/fd/{fd}") == "/dev/uinput":
+                    return int(fd)
+            except OSError:
+                continue
+        raise RuntimeError("No dev/input open")
 
-    def __del__(self) -> None:
-        self._ff_stop.set()
-        if self._ff_thread is not None:
-            self._ff_thread.join(timeout=1.0)
+    def register_notification(self, callback_function: Callable[..., Any]) -> None:
+        """Register a callback for force-feedback notifications.
 
-    @abstractmethod
-    def target_alloc(self) -> Any:
-        """Return the pointer to an allocated evdev device."""
-        ...
+        On Linux force feedback is implemented by reading ``FF_RUMBLE``
+        events from the uinput device.  The callback receives the same
+        signature as Windows:
+
+            ``callback(client, target, large_motor, small_motor, led_number, user_data)``
+
+        ``large_motor`` and ``small_motor`` are scaled to 0-255 from the
+        kernel's 0-65535 range.
+        """
+        if signature(callback_function) != signature(_dummy_callback):
+            raise TypeError(
+                f"Expected callback signature: {signature(_dummy_callback)}, "
+                f"got: {signature(callback_function)}"
+            )
+
+        self._ff_callback = callback_function
+
+        if self._ff_thread is not None:
+            return
+        uinput_fd = self.get_raw_uinput_fd()
+        if uinput_fd is None:
+            return
+
+        self._ff_stop.clear()
+        self._ff_thread = threading.Thread(
+            target=self._ff_reader_loop,
+            args=(uinput_fd,),
+            daemon=True,
+        )
+        self._ff_thread.start()
+
+    def _ff_reader_loop(self, fd: int) -> None:
+        """Background thread: reads EV_FF / EV_UINPUT events and dispatches rumble callbacks."""
+        os.set_blocking(fd, False)
+        while not self._ff_stop.is_set():
+            ready, _, _ = select.select([fd], [], [], 0.1)
+            if not ready:
+                continue
+            try:
+                data = os.read(fd, 24)
+            except OSError:
+                continue
+            if len(data) < 24:
+                continue
+            _sec, _usec, ev_type, ev_code, ev_value = struct.unpack("llHHi", data)
+            if ev_type == _EV_FF and ev_code in self._ff_effects:
+                strong, weak = self._ff_effects[ev_code]
+                large_motor = (strong * 255) // 65535 if strong else 0
+                small_motor = (weak * 255) // 65535 if weak else 0
+                if self._ff_callback:
+                    try:
+                        self._ff_callback(None, None, large_motor, small_motor, 0, None)
+                    except Exception:
+                        logger.opt(exception=True).debug("FF callback raised")
+            elif ev_type == _EV_UINPUT:
+                if ev_code == _UI_FF_UPLOAD:
+                    self._handle_ff_upload(fd, ev_value)
+                elif ev_code == _UI_FF_ERASE:
+                    self._handle_ff_erase(fd, ev_value)
+
+
+def unregister_notification(self) -> None:
+    """Unregister a previously registered callback function."""
+    self._ff_callback = None
+    self._ff_stop.set()
+    if self._ff_thread is not None:
+        self._ff_thread.join(timeout=2.0)
+        self._ff_thread = None
+    self._ff_effects.clear()
+
+
+def __del__(self) -> None:
+    self._ff_stop.set()
+    if self._ff_thread is not None:
+        self._ff_thread.join(timeout=1.0)
+
+
+@abstractmethod
+def target_alloc(self) -> Any:
+    """Return the pointer to an allocated evdev device."""
+    ...
 
 
 class VX360Gamepad(VGamepad):

--- a/vgamepad/lin/virtual_gamepad.py
+++ b/vgamepad/lin/virtual_gamepad.py
@@ -1,73 +1,287 @@
-"""
-VGamepad API (Linux)
-"""
+"""VGamepad API (Linux) - uinput backend via libevdev."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import fcntl
+import os
+import select
+import struct
+import threading
 from abc import ABC, abstractmethod
-from time import sleep
+from collections.abc import Callable
+from inspect import signature
+from typing import Any, ClassVar
 
 import libevdev
+from loguru import logger
+
 import vgamepad.win.vigem_commons as vcom
+
+
+def _ioc(direction: int, ioc_type: int, nr: int, size: int) -> int:
+    return (direction << 30) | (ioc_type << 8) | (nr << 0) | (size << 16)
+
+
+def _iowr(ioc_type: int, nr: int, size: int) -> int:
+    return _ioc(3, ioc_type, nr, size)
+
+
+def _iow(ioc_type: int, nr: int, size: int) -> int:
+    return _ioc(1, ioc_type, nr, size)
+
+
+_UINPUT_IOCTL_BASE = ord("U")
+
+_PTR_SIZE = ctypes.sizeof(ctypes.c_void_p)
+_FF_EFFECT_SIZE = 44 if _PTR_SIZE == 4 else 48
+_FF_UPLOAD_SIZE = 4 + 4 + _FF_EFFECT_SIZE + _FF_EFFECT_SIZE
+_FF_ERASE_SIZE = 12
+
+UI_BEGIN_FF_UPLOAD = _iowr(_UINPUT_IOCTL_BASE, 200, _FF_UPLOAD_SIZE)
+UI_END_FF_UPLOAD = _iow(_UINPUT_IOCTL_BASE, 201, _FF_UPLOAD_SIZE)
+UI_BEGIN_FF_ERASE = _iowr(_UINPUT_IOCTL_BASE, 202, _FF_ERASE_SIZE)
+UI_END_FF_ERASE = _iow(_UINPUT_IOCTL_BASE, 203, _FF_ERASE_SIZE)
+
+_EV_FF = 0x15
+_EV_UINPUT = 0x0101
+_FF_RUMBLE = 0x50
+
+_UI_FF_UPLOAD = 1
+_UI_FF_ERASE = 2
+
+_RUMBLE_STRONG_OFFSET = 14 if _PTR_SIZE == 4 else 16
+_RUMBLE_WEAK_OFFSET = _RUMBLE_STRONG_OFFSET + 2
+_EFFECT_ID_OFFSET = 2
+
+
+class _FFUpload(ctypes.Structure):
+    """Mirrors struct uinput_ff_upload."""
+
+    _fields_ = [
+        ("request_id", ctypes.c_uint32),
+        ("retval", ctypes.c_int32),
+        ("effect", ctypes.c_ubyte * _FF_EFFECT_SIZE),
+        ("old", ctypes.c_ubyte * _FF_EFFECT_SIZE),
+    ]
+
+
+class _FFErase(ctypes.Structure):
+    """Mirrors struct uinput_ff_erase."""
+
+    _fields_ = [
+        ("request_id", ctypes.c_uint32),
+        ("retval", ctypes.c_int32),
+        ("effect_id", ctypes.c_uint32),
+    ]
+
+
+def _dummy_callback(
+    client: Any,
+    target: Any,
+    large_motor: int,
+    small_motor: int,
+    led_number: int,
+    user_data: Any,
+) -> None:
+    pass
+
+
+def _parse_ff_rumble(raw_bytes: bytes) -> tuple[int | None, int | None]:
+    """Extract rumble magnitudes from an ff_effect struct.
+
+    Returns ``(strong, weak)`` as 0-65535 values, or ``(None, None)``
+    if the effect is not ``FF_RUMBLE``.
+    """
+    if len(raw_bytes) < _RUMBLE_WEAK_OFFSET + 2:
+        return None, None
+    effect_type = struct.unpack_from("<H", raw_bytes, 0)[0]
+    if effect_type != _FF_RUMBLE:
+        return None, None
+    strong, weak = struct.unpack_from("<HH", raw_bytes, _RUMBLE_STRONG_OFFSET)
+    return strong, weak
 
 
 class VGamepad(ABC):
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.device = libevdev.Device()
-        self.device.name = 'Virtual Gamepad'
+        self.device.name = "Virtual Gamepad"
+        self._ff_thread: threading.Thread | None = None
+        self._ff_stop = threading.Event()
+        self._ff_callback: Callable[..., Any] | None = None
+        self._ff_effects: dict[int, tuple[int, int]] = {}
 
-    def get_vid(self):
-        """
-        :return: the vendor ID of the virtual device
-        """
+    def get_vid(self) -> int:
+        """Return the vendor ID of the virtual device."""
         return self.device.id.vendor
 
-    def get_pid(self):
-        """
-        :return: the product ID of the virtual device
-        """
+    def get_pid(self) -> int:
+        """Return the product ID of the virtual device."""
         return self.device.id.product
 
-    def set_vid(self, vid):
-        """
-        :param: the new vendor ID of the virtual device
-        """
-        self.device.id = {'vendor': vid}  # setter only uses set keys
+    def set_vid(self, vid: int) -> None:
+        """Set the vendor ID of the virtual device."""
+        self.device.id = {"vendor": vid}
 
-    def set_pid(self, pid):
-        """
-        :param: the new product ID of the virtual device
-        """
-        self.device.id = {'product': pid}  # setter only uses set keys
+    def set_pid(self, pid: int) -> None:
+        """Set the product ID of the virtual device."""
+        self.device.id = {"product": pid}
 
-    def get_index(self):
-        """
-        :return: the internally used index of the target device
-        """
+    def get_index(self) -> int:
+        """Return the internally used index of the target device."""
         return 0
 
-    def get_type(self):
-        """
-        :return: the type of the object (e.g. Xbox360Wired)
-        """
+    def get_type(self) -> int:
+        """Return the type of the object (bus type)."""
         return self.device.id.bustype
 
+    def register_notification(self, callback_function: Callable[..., Any]) -> None:
+        """Register a callback for force-feedback notifications.
+
+        On Linux force feedback is implemented by reading ``FF_RUMBLE``
+        events from the uinput device.  The callback receives the same
+        signature as Windows:
+
+            ``callback(client, target, large_motor, small_motor, led_number, user_data)``
+
+        ``large_motor`` and ``small_motor`` are scaled to 0-255 from the
+        kernel's 0-65535 range.
+        """
+        if signature(callback_function) != signature(_dummy_callback):
+            raise TypeError(
+                f"Expected callback signature: {signature(_dummy_callback)}, "
+                f"got: {signature(callback_function)}"
+            )
+
+        self._ff_callback = callback_function
+
+        if self._ff_thread is not None:
+            return
+
+        devnode = self.uinput.devnode
+        if devnode is None:
+            return
+
+        self._ff_stop.clear()
+        self._ff_thread = threading.Thread(
+            target=self._ff_reader_loop,
+            args=(devnode,),
+            daemon=True,
+        )
+        self._ff_thread.start()
+
+    def _ff_reader_loop(self, devnode: str) -> None:
+        """Background thread: reads EV_FF / EV_UINPUT events and dispatches rumble callbacks."""
+        try:
+            fd = os.open(devnode, os.O_RDWR | os.O_NONBLOCK)
+        except OSError:
+            logger.warning("Could not open {} for force-feedback reading", devnode)
+            return
+        try:
+            while not self._ff_stop.is_set():
+                ready, _, _ = select.select([fd], [], [], 0.1)
+                if not ready:
+                    continue
+                try:
+                    data = os.read(fd, 24)
+                except OSError:
+                    continue
+                if len(data) < 24:
+                    continue
+                _sec, _usec, ev_type, ev_code, ev_value = struct.unpack("llHHi", data)
+                if ev_type == _EV_FF and ev_code in self._ff_effects:
+                    strong, weak = self._ff_effects[ev_code]
+                    large_motor = (strong * 255) // 65535 if strong else 0
+                    small_motor = (weak * 255) // 65535 if weak else 0
+                    if self._ff_callback:
+                        try:
+                            self._ff_callback(None, None, large_motor, small_motor, 0, None)
+                        except Exception:
+                            logger.opt(exception=True).debug("FF callback raised")
+                elif ev_type == _EV_UINPUT:
+                    if ev_code == _UI_FF_UPLOAD:
+                        self._handle_ff_upload(fd, ev_value)
+                    elif ev_code == _UI_FF_ERASE:
+                        self._handle_ff_erase(fd, ev_value)
+        finally:
+            os.close(fd)
+
+    def _handle_ff_upload(self, fd: int, request_id: int) -> None:
+        """Handle a UI_FF_UPLOAD request from the kernel."""
+        upload = _FFUpload()
+        upload.request_id = request_id
+        try:
+            fcntl.ioctl(fd, UI_BEGIN_FF_UPLOAD, upload)
+        except OSError:
+            return
+        effect_bytes = bytes(upload.effect)
+        strong, weak = _parse_ff_rumble(effect_bytes)
+        effect_id = struct.unpack_from("<h", effect_bytes, _EFFECT_ID_OFFSET)[0]
+        if effect_id < 0:
+            effect_id = len(self._ff_effects)
+            struct.pack_into("<h", upload.effect, _EFFECT_ID_OFFSET, effect_id)
+        if strong is not None:
+            self._ff_effects[effect_id] = (strong, weak)  # type: ignore[arg-type]
+        upload.retval = 0
+        with contextlib.suppress(OSError):
+            fcntl.ioctl(fd, UI_END_FF_UPLOAD, upload)
+
+    def _handle_ff_erase(self, fd: int, request_id: int) -> None:
+        """Handle a UI_FF_ERASE request from the kernel."""
+        erase = _FFErase()
+        erase.request_id = request_id
+        try:
+            fcntl.ioctl(fd, UI_BEGIN_FF_ERASE, erase)
+        except OSError:
+            return
+        self._ff_effects.pop(erase.effect_id, None)
+        erase.retval = 0
+        with contextlib.suppress(OSError):
+            fcntl.ioctl(fd, UI_END_FF_ERASE, erase)
+
+    def unregister_notification(self) -> None:
+        """Unregister a previously registered callback function."""
+        self._ff_callback = None
+        self._ff_stop.set()
+        if self._ff_thread is not None:
+            self._ff_thread.join(timeout=2.0)
+            self._ff_thread = None
+        self._ff_effects.clear()
+
+    def __del__(self) -> None:
+        self._ff_stop.set()
+        if self._ff_thread is not None:
+            self._ff_thread.join(timeout=1.0)
+
     @abstractmethod
-    def target_alloc(self):
-        """
-        :return: the pointer to an allocated evdev device (e.g. create_uinput_device())
-        """
-        pass
+    def target_alloc(self) -> Any:
+        """Return the pointer to an allocated evdev device."""
+        ...
 
 
 class VX360Gamepad(VGamepad):
-    """
-    Virtual Xbox360 gamepad
-    """
+    """Virtual Xbox 360 gamepad (Linux / uinput)."""
 
-    def __init__(self):
+    XUSB_BUTTON_TO_EV_KEY: ClassVar[dict[vcom.XUSB_BUTTON, Any]] = {
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_START: libevdev.EV_KEY.BTN_START,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_BACK: libevdev.EV_KEY.BTN_SELECT,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_THUMB: libevdev.EV_KEY.BTN_THUMBL,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_THUMB: libevdev.EV_KEY.BTN_THUMBR,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER: libevdev.EV_KEY.BTN_TL,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_SHOULDER: libevdev.EV_KEY.BTN_TR,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_GUIDE: libevdev.EV_KEY.BTN_MODE,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_A: libevdev.EV_KEY.BTN_SOUTH,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_B: libevdev.EV_KEY.BTN_EAST,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_X: libevdev.EV_KEY.BTN_NORTH,
+        vcom.XUSB_BUTTON.XUSB_GAMEPAD_Y: libevdev.EV_KEY.BTN_WEST,
+    }
+
+    def __init__(self) -> None:
         super().__init__()
-        self.device.name = 'Xbox 360 Controller'
+        self.device.name = "Xbox 360 Controller"
 
-        # Enable buttons
         self.device.enable(libevdev.EV_KEY.BTN_SOUTH)
         self.device.enable(libevdev.EV_KEY.BTN_EAST)
         self.device.enable(libevdev.EV_KEY.BTN_NORTH)
@@ -79,255 +293,184 @@ class VX360Gamepad(VGamepad):
         self.device.enable(libevdev.EV_KEY.BTN_SELECT)
         self.device.enable(libevdev.EV_KEY.BTN_START)
 
-        # self.device.enable(libevdev.EV_KEY.BTN_MODE)  # FIXME: On Linux, this messes up the button order
+        self.device.enable(libevdev.EV_KEY.BTN_MODE)
 
         self.device.enable(libevdev.EV_KEY.BTN_THUMBL)
         self.device.enable(libevdev.EV_KEY.BTN_THUMBR)
 
-        # Enable joysticks
         self.device.enable(
             libevdev.EV_ABS.ABS_X,
-            libevdev.InputAbsInfo(minimum=-32768,
-                                  maximum=32767,
-                                  fuzz=16,
-                                  flat=128))
+            libevdev.InputAbsInfo(minimum=-32768, maximum=32767, fuzz=16, flat=128),
+        )
         self.device.enable(
             libevdev.EV_ABS.ABS_Y,
-            libevdev.InputAbsInfo(minimum=-32768,
-                                  maximum=32767,
-                                  fuzz=16,
-                                  flat=128))
+            libevdev.InputAbsInfo(minimum=-32768, maximum=32767, fuzz=16, flat=128),
+        )
         self.device.enable(
             libevdev.EV_ABS.ABS_RX,
-            libevdev.InputAbsInfo(minimum=-32768,
-                                  maximum=32767,
-                                  fuzz=16,
-                                  flat=128))
+            libevdev.InputAbsInfo(minimum=-32768, maximum=32767, fuzz=16, flat=128),
+        )
         self.device.enable(
             libevdev.EV_ABS.ABS_RY,
-            libevdev.InputAbsInfo(minimum=-32768,
-                                  maximum=32767,
-                                  fuzz=16,
-                                  flat=128))
-        # Enable triggers
+            libevdev.InputAbsInfo(minimum=-32768, maximum=32767, fuzz=16, flat=128),
+        )
         self.device.enable(libevdev.EV_ABS.ABS_Z, libevdev.InputAbsInfo(minimum=0, maximum=1023))
         self.device.enable(libevdev.EV_ABS.ABS_RZ, libevdev.InputAbsInfo(minimum=0, maximum=1023))
 
-        # Enable D-Pad
         self.device.enable(libevdev.EV_ABS.ABS_HAT0X, libevdev.InputAbsInfo(minimum=-1, maximum=1))
         self.device.enable(libevdev.EV_ABS.ABS_HAT0Y, libevdev.InputAbsInfo(minimum=-1, maximum=1))
+
+        self.device.enable(libevdev.EV_FF.FF_RUMBLE)
+        self.device.enable(libevdev.EV_FF.FF_PERIODIC)
+        self.device.enable(libevdev.EV_FF.FF_SQUARE)
+        self.device.enable(libevdev.EV_FF.FF_TRIANGLE)
+        self.device.enable(libevdev.EV_FF.FF_SINE)
+        self.device.enable(libevdev.EV_FF.FF_GAIN)
 
         self.uinput = self.device.create_uinput_device()
 
         self.report = self.get_default_report()
         self.update()
+        logger.debug("VX360Gamepad created on {}", self.uinput.devnode)
 
-    XUSB_BUTTON_TO_EV_KEY = {
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_START: libevdev.EV_KEY.BTN_START,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_BACK: libevdev.EV_KEY.BTN_SELECT,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_THUMB: libevdev.EV_KEY.BTN_THUMBL,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_THUMB: libevdev.EV_KEY.BTN_THUMBR,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER: libevdev.EV_KEY.BTN_TL,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_SHOULDER: libevdev.EV_KEY.BTN_TR,
-        # vcom.XUSB_BUTTON.XUSB_GAMEPAD_GUIDE: libevdev.EV_KEY.BTN_MODE,  # FIXME: does not work properly on Linux
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_A: libevdev.EV_KEY.BTN_SOUTH,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_B: libevdev.EV_KEY.BTN_EAST,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_X: libevdev.EV_KEY.BTN_NORTH,
-        vcom.XUSB_BUTTON.XUSB_GAMEPAD_Y: libevdev.EV_KEY.BTN_WEST,
-    }
+    def get_default_report(self) -> vcom.XUSB_REPORT:
+        return vcom.XUSB_REPORT(
+            wButtons=0,
+            bLeftTrigger=0,
+            bRightTrigger=0,
+            sThumbLX=0,
+            sThumbLY=0,
+            sThumbRX=0,
+            sThumbRY=0,
+        )
 
-    def get_default_report(self):
-        return vcom.XUSB_REPORT(wButtons=0,
-                                bLeftTrigger=0,
-                                bRightTrigger=0,
-                                sThumbLX=0,
-                                sThumbLY=0,
-                                sThumbRX=0,
-                                sThumbRY=0)
-
-    def reset(self):
-        """
-        Resets the report to the default state
-        """
+    def reset(self) -> None:
+        """Reset the report to the default state."""
         self.report = self.get_default_report()
 
-    def press_button(self, button):
-        """
-        Presses a button (no effect if already pressed)
-        All possible buttons are in XUSB_BUTTON
-        Note: The GUIDE button is not available on Linux
+    def press_button(self, button: vcom.XUSB_BUTTON) -> None:
+        """Press a button (no effect if already pressed).
 
-        :param: a XUSB_BUTTON field, e.g. XUSB_BUTTON.XUSB_GAMEPAD_X
+        :param button: an ``XUSB_BUTTON`` field, e.g. ``XUSB_BUTTON.XUSB_GAMEPAD_X``
         """
         self.report.wButtons = self.report.wButtons | button
 
-    def release_button(self, button):
-        """
-        Releases a button (no effect if already released)
-        All possible buttons are in XUSB_BUTTON
+    def release_button(self, button: vcom.XUSB_BUTTON) -> None:
+        """Release a button (no effect if already released).
 
-        :param: a XUSB_BUTTON field, e.g. XUSB_BUTTON.XUSB_GAMEPAD_X
+        :param button: an ``XUSB_BUTTON`` field, e.g. ``XUSB_BUTTON.XUSB_GAMEPAD_X``
         """
         self.report.wButtons = self.report.wButtons & ~button
 
-    def left_trigger(self, value):
-        """
-        Sets the value of the left trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def left_trigger(self, value: int) -> None:
+        """Set the left trigger value (0-255, 0 = released)."""
         self.report.bLeftTrigger = value
 
-    def right_trigger(self, value):
-        """
-        Sets the value of the right trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def right_trigger(self, value: int) -> None:
+        """Set the right trigger value (0-255, 0 = released)."""
         self.report.bRightTrigger = value
 
-    def left_trigger_float(self, value_float):
-        """
-        Sets the value of the left trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def left_trigger_float(self, value_float: float) -> None:
+        """Set the left trigger value (0.0-1.0, 0.0 = released)."""
         self.left_trigger(round(value_float * 255))
 
-    def right_trigger_float(self, value_float):
-        """
-        Sets the value of the right trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def right_trigger_float(self, value_float: float) -> None:
+        """Set the right trigger value (0.0-1.0, 0.0 = released)."""
         self.right_trigger(round(value_float * 255))
 
-    def left_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the left joystick
-
-        :param: integer between -32768 and 32767 (0 = neutral position)
-        """
+    def left_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the left joystick axes (-32768 to 32767, 0 = neutral)."""
         self.report.sThumbLX = x_value
         self.report.sThumbLY = y_value
 
-    def right_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: integer between -32768 and 32767 (0 = neutral position)
-        """
+    def right_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the right joystick axes (-32768 to 32767, 0 = neutral)."""
         self.report.sThumbRX = x_value
         self.report.sThumbRY = y_value
 
-    def left_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the left joystick
+    def left_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the left joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
+        self.left_joystick(round(x_value_float * 32767), round(y_value_float * 32767))
 
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
-        self.left_joystick(round(x_value_float * 32767),
-                           round(y_value_float * 32767))
+    def right_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the right joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
+        self.right_joystick(round(x_value_float * 32767), round(y_value_float * 32767))
 
-    def right_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
-        self.right_joystick(round(x_value_float * 32767),
-                            round(y_value_float * 32767))
-
-    def update(self):
-        """
-        Sends the current report (i.e. commands) to the virtual device
-        """
-        # Update buttons
+    def update(self) -> None:
+        """Send the current report to the virtual device."""
         for btn, key in self.XUSB_BUTTON_TO_EV_KEY.items():
             self.uinput.send_events([
-                libevdev.InputEvent(key, value=(int(bool(self.report.wButtons & btn)))),
+                libevdev.InputEvent(key, value=int(bool(self.report.wButtons & btn))),
             ])
 
-        # Update axes
         self.uinput.send_events([
-            # Left joystick
             libevdev.InputEvent(libevdev.EV_ABS.ABS_X, value=self.report.sThumbLX),
             libevdev.InputEvent(libevdev.EV_ABS.ABS_Y, value=self.report.sThumbLY),
-            # Right joystick
             libevdev.InputEvent(libevdev.EV_ABS.ABS_RX, value=self.report.sThumbRX),
             libevdev.InputEvent(libevdev.EV_ABS.ABS_RY, value=self.report.sThumbRY),
-            # Triggers
             libevdev.InputEvent(libevdev.EV_ABS.ABS_Z, value=self.report.bLeftTrigger * 4),
-            libevdev.InputEvent(libevdev.EV_ABS.ABS_RZ, value=self.report.bRightTrigger * 4)
+            libevdev.InputEvent(libevdev.EV_ABS.ABS_RZ, value=self.report.bRightTrigger * 4),
         ])
 
-        hat0x_value = bool(self.report.wButtons
-                           & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_RIGHT) - bool(
-                               self.report.wButtons
-                               & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_LEFT)
-        hat0y_value = bool(self.report.wButtons
-                           & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_DOWN) - bool(
-                               self.report.wButtons
-                               & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_UP)
+        hat0x_value = int(bool(self.report.wButtons & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_RIGHT)) - int(
+            bool(self.report.wButtons & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_LEFT)
+        )
+        hat0y_value = int(bool(self.report.wButtons & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_DOWN)) - int(
+            bool(self.report.wButtons & vcom.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_UP)
+        )
         self.uinput.send_events([
             libevdev.InputEvent(libevdev.EV_ABS.ABS_HAT0X, value=hat0x_value),
-            libevdev.InputEvent(libevdev.EV_ABS.ABS_HAT0Y, value=hat0y_value)
+            libevdev.InputEvent(libevdev.EV_ABS.ABS_HAT0Y, value=hat0y_value),
         ])
 
         self.uinput.send_events([libevdev.InputEvent(libevdev.EV_SYN.SYN_REPORT, value=0)])
 
-    def target_alloc(self):
+    def target_alloc(self) -> Any:
         return self.uinput
 
 
 class VDS4Gamepad(VGamepad):
-    """
-    Virtual DuslaShock 4 gamepad
-    """
+    """Virtual DualShock 4 gamepad (Linux / uinput)."""
 
-    def __init__(self):
+    DS4_BUTTON_TO_EV_KEY: ClassVar[dict[vcom.DS4_BUTTONS, Any]] = {
+        vcom.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT: libevdev.EV_KEY.BTN_THUMBR,
+        vcom.DS4_BUTTONS.DS4_BUTTON_THUMB_LEFT: libevdev.EV_KEY.BTN_THUMBL,
+        vcom.DS4_BUTTONS.DS4_BUTTON_OPTIONS: libevdev.EV_KEY.BTN_SELECT,
+        vcom.DS4_BUTTONS.DS4_BUTTON_SHARE: libevdev.EV_KEY.BTN_START,
+        vcom.DS4_BUTTONS.DS4_BUTTON_TRIGGER_RIGHT: libevdev.EV_KEY.BTN_TR2,
+        vcom.DS4_BUTTONS.DS4_BUTTON_TRIGGER_LEFT: libevdev.EV_KEY.BTN_TL2,
+        vcom.DS4_BUTTONS.DS4_BUTTON_SHOULDER_RIGHT: libevdev.EV_KEY.BTN_TR,
+        vcom.DS4_BUTTONS.DS4_BUTTON_SHOULDER_LEFT: libevdev.EV_KEY.BTN_TL,
+        vcom.DS4_BUTTONS.DS4_BUTTON_TRIANGLE: libevdev.EV_KEY.BTN_NORTH,
+        vcom.DS4_BUTTONS.DS4_BUTTON_CIRCLE: libevdev.EV_KEY.BTN_EAST,
+        vcom.DS4_BUTTONS.DS4_BUTTON_CROSS: libevdev.EV_KEY.BTN_SOUTH,
+        vcom.DS4_BUTTONS.DS4_BUTTON_SQUARE: libevdev.EV_KEY.BTN_WEST,
+    }
+
+    DS4_SPECIAL_BUTTON_TO_EV_KEY: ClassVar[dict[vcom.DS4_SPECIAL_BUTTONS, Any]] = {
+        vcom.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS: libevdev.EV_KEY.BTN_MODE,
+        vcom.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD: libevdev.EV_KEY.BTN_TOUCH,
+    }
+
+    DPAD_MAPPING: ClassVar[dict[vcom.DS4_DPAD_DIRECTIONS, tuple[int, int]]] = {
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE: (0, 0),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_EAST: (1, 0),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHEAST: (1, 1),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTH: (0, 1),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHWEST: (-1, 1),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_WEST: (-1, 0),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST: (-1, -1),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTH: (0, -1),
+        vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHEAST: (1, -1),
+    }
+
+    def __init__(self) -> None:
         super().__init__()
 
         self.dpad_direction = vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE
 
-        self.dpad_mapping = {
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NONE: (0, 0),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_EAST: (1, 0),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHEAST: (1, 1),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTH: (0, 1),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_SOUTHWEST: (-1, 1),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_WEST: (-1, 0),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST: (-1, -1),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTH: (0, -1),
-            vcom.DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHEAST: (1, -1)
-        }
+        self.device.name = "Sony Interactive Entertainment Wireless Controller"
 
-        self.DS4_BUTTON_TO_EV_KEY = {
-            vcom.DS4_BUTTONS.DS4_BUTTON_THUMB_RIGHT: libevdev.EV_KEY.BTN_THUMBR,
-            vcom.DS4_BUTTONS.DS4_BUTTON_THUMB_LEFT: libevdev.EV_KEY.BTN_THUMBL,
-            vcom.DS4_BUTTONS.DS4_BUTTON_OPTIONS: libevdev.EV_KEY.BTN_SELECT,
-            vcom.DS4_BUTTONS.DS4_BUTTON_SHARE: libevdev.EV_KEY.BTN_START,
-            vcom.DS4_BUTTONS.DS4_BUTTON_SHOULDER_RIGHT: libevdev.EV_KEY.BTN_TR,
-            vcom.DS4_BUTTONS.DS4_BUTTON_SHOULDER_LEFT: libevdev.EV_KEY.BTN_TL,
-            vcom.DS4_BUTTONS.DS4_BUTTON_TRIANGLE: libevdev.EV_KEY.BTN_NORTH,
-            vcom.DS4_BUTTONS.DS4_BUTTON_CIRCLE: libevdev.EV_KEY.BTN_EAST,
-            vcom.DS4_BUTTONS.DS4_BUTTON_CROSS: libevdev.EV_KEY.BTN_SOUTH,
-            vcom.DS4_BUTTONS.DS4_BUTTON_SQUARE: libevdev.EV_KEY.BTN_WEST,
-        }
-
-        self.DS4_SPECIAL_BUTTON_TO_EV_KEY = {
-            vcom.DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_PS: libevdev.EV_KEY.BTN_MODE,
-        }
-
-        # Note: physical DS4 controllers create 3 evdev files on Linux:
-        # 1: Sony Interactive Entertainment Wireless Controller
-        # 2: Sony Interactive Entertainment Wireless Controller Motion Sensors
-        # 3: Sony Interactive Entertainment Wireless Controller Touchpad
-        # TODO: emulate the motion sensors and touchpad on Linux
-
-        self.device.name = 'Sony Interactive Entertainment Wireless Controller'  # 'PS4 Controller'
-
-        # Enable buttons
         self.device.enable(libevdev.EV_KEY.BTN_SOUTH)
         self.device.enable(libevdev.EV_KEY.BTN_EAST)
         self.device.enable(libevdev.EV_KEY.BTN_NORTH)
@@ -341,8 +484,8 @@ class VDS4Gamepad(VGamepad):
         self.device.enable(libevdev.EV_KEY.BTN_MODE)
         self.device.enable(libevdev.EV_KEY.BTN_THUMBL)
         self.device.enable(libevdev.EV_KEY.BTN_THUMBR)
+        self.device.enable(libevdev.EV_KEY.BTN_TOUCH)
 
-        # Enable axes
         self.device.enable(libevdev.EV_ABS.ABS_X, libevdev.InputAbsInfo(minimum=0, maximum=255, value=127))
         self.device.enable(libevdev.EV_ABS.ABS_Y, libevdev.InputAbsInfo(minimum=0, maximum=255, value=127))
         self.device.enable(libevdev.EV_ABS.ABS_RX, libevdev.InputAbsInfo(minimum=0, maximum=255, value=127))
@@ -350,16 +493,23 @@ class VDS4Gamepad(VGamepad):
         self.device.enable(libevdev.EV_ABS.ABS_HAT0X, libevdev.InputAbsInfo(minimum=-1, maximum=1, value=0))
         self.device.enable(libevdev.EV_ABS.ABS_HAT0Y, libevdev.InputAbsInfo(minimum=-1, maximum=1, value=0))
 
-        # Enable triggers
         self.device.enable(libevdev.EV_ABS.ABS_Z, libevdev.InputAbsInfo(minimum=0, maximum=255))
         self.device.enable(libevdev.EV_ABS.ABS_RZ, libevdev.InputAbsInfo(minimum=0, maximum=255))
+
+        self.device.enable(libevdev.EV_FF.FF_RUMBLE)
+        self.device.enable(libevdev.EV_FF.FF_PERIODIC)
+        self.device.enable(libevdev.EV_FF.FF_SQUARE)
+        self.device.enable(libevdev.EV_FF.FF_TRIANGLE)
+        self.device.enable(libevdev.EV_FF.FF_SINE)
+        self.device.enable(libevdev.EV_FF.FF_GAIN)
 
         self.uinput = self.device.create_uinput_device()
 
         self.report = self.get_default_report()
         self.update()
+        logger.debug("VDS4Gamepad created on {}", self.uinput.devnode)
 
-    def get_default_report(self):
+    def get_default_report(self) -> vcom.DS4_REPORT:
         rep = vcom.DS4_REPORT(
             bThumbLX=0,
             bThumbLY=0,
@@ -368,165 +518,136 @@ class VDS4Gamepad(VGamepad):
             wButtons=0,
             bSpecial=0,
             bTriggerL=0,
-            bTriggerR=0)
+            bTriggerR=0,
+        )
         vcom.DS4_REPORT_INIT(rep)
         return rep
 
-    def reset(self):
-        """
-        Resets the report to the default state
-        """
+    def reset(self) -> None:
+        """Reset the report to the default state."""
         self.report = self.get_default_report()
 
-    def press_button(self, button):
-        """
-        Presses a button (no effect if already pressed)
-        All possible buttons are in DS4_BUTTONS
+    def press_button(self, button: vcom.DS4_BUTTONS) -> None:
+        """Press a button (no effect if already pressed).
 
-        :param: a DS4_BUTTONS field, e.g. DS4_BUTTONS.DS4_BUTTON_TRIANGLE
+        :param button: a ``DS4_BUTTONS`` field, e.g. ``DS4_BUTTONS.DS4_BUTTON_TRIANGLE``
         """
         self.report.wButtons = self.report.wButtons | button
 
-    def release_button(self, button):
-        """
-        Releases a button (no effect if already released)
-        All possible buttons are in DS4_BUTTONS
+    def release_button(self, button: vcom.DS4_BUTTONS) -> None:
+        """Release a button (no effect if already released).
 
-        :param: a DS4_BUTTONS field, e.g. DS4_BUTTONS.DS4_BUTTON_TRIANGLE
+        :param button: a ``DS4_BUTTONS`` field, e.g. ``DS4_BUTTONS.DS4_BUTTON_TRIANGLE``
         """
         self.report.wButtons = self.report.wButtons & ~button
 
-    def press_special_button(self, special_button):
-        """
-        Presses a special button (no effect if already pressed)
-        All possible buttons are in DS4_SPECIAL_BUTTONS
+    def press_special_button(self, special_button: vcom.DS4_SPECIAL_BUTTONS) -> None:
+        """Press a special button (no effect if already pressed).
 
-        :param: a DS4_SPECIAL_BUTTONS field, e.g. DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD
+        :param special_button: a ``DS4_SPECIAL_BUTTONS`` field
         """
         self.report.bSpecial = self.report.bSpecial | special_button
 
-    def release_special_button(self, special_button):
-        """
-        Releases a special button (no effect if already released)
-        All possible buttons are in DS4_SPECIAL_BUTTONS
+    def release_special_button(self, special_button: vcom.DS4_SPECIAL_BUTTONS) -> None:
+        """Release a special button (no effect if already released).
 
-        :param: a DS4_SPECIAL_BUTTONS field, e.g. DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD
+        :param special_button: a ``DS4_SPECIAL_BUTTONS`` field
         """
         self.report.bSpecial = self.report.bSpecial & ~special_button
 
-    def left_trigger(self, value):
-        """
-        Sets the value of the left trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def left_trigger(self, value: int) -> None:
+        """Set the left trigger value (0-255, 0 = released)."""
         self.report.bTriggerL = value
 
-    def right_trigger(self, value):
-        """
-        Sets the value of the right trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def right_trigger(self, value: int) -> None:
+        """Set the right trigger value (0-255, 0 = released)."""
         self.report.bTriggerR = value
 
-    def left_trigger_float(self, value_float):
-        """
-        Sets the value of the left trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def left_trigger_float(self, value_float: float) -> None:
+        """Set the left trigger value (0.0-1.0, 0.0 = released)."""
         self.left_trigger(round(value_float * 255))
 
-    def right_trigger_float(self, value_float):
-        """
-        Sets the value of the right trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def right_trigger_float(self, value_float: float) -> None:
+        """Set the right trigger value (0.0-1.0, 0.0 = released)."""
         self.right_trigger(round(value_float * 255))
 
-    def left_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the left joystick
-
-        :param: integer between 0 and 255 (128 = neutral position)
-        """
+    def left_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the left joystick axes (0-255, 128 = neutral)."""
         self.report.bThumbLX = x_value
         self.report.bThumbLY = y_value
 
-    def right_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: integer between 0 and 255 (128 = neutral position)
-        """
+    def right_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the right joystick axes (0-255, 128 = neutral)."""
         self.report.bThumbRX = x_value
         self.report.bThumbRY = y_value
 
-    def left_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the left joystick
+    def left_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the left joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
+        self.left_joystick(128 + round(x_value_float * 127), 128 + round(y_value_float * 127))
 
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
-        self.left_joystick(128 + round(x_value_float * 127),
-                           128 + round(y_value_float * 127))
+    def right_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the right joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
+        self.right_joystick(128 + round(x_value_float * 127), 128 + round(y_value_float * 127))
 
-    def right_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the right joystick
+    def directional_pad(self, direction: vcom.DS4_DPAD_DIRECTIONS) -> None:
+        """Set the directional pad (hat) direction.
 
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
-        self.right_joystick(128 + round(x_value_float * 127),
-                            128 + round(y_value_float * 127))
-
-    def directional_pad(self, direction):
-        """
-        Sets the direction of the directional pad (hat)
-        All possible directions are in DS4_DPAD_DIRECTIONS
-
-        :param: a DS4_DPAD_DIRECTIONS field, e.g. DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST
+        :param direction: a ``DS4_DPAD_DIRECTIONS`` field
         """
         vcom.DS4_SET_DPAD(self.report, direction)
         self.dpad_direction = direction
 
-    def update(self):
-        """
-        Sends the current report (i.e. commands) to the virtual device
-        """
+    def update(self) -> None:
+        """Send the current report to the virtual device."""
         for btn, key in self.DS4_BUTTON_TO_EV_KEY.items():
             self.uinput.send_events([
-                libevdev.InputEvent(key, value=(int(bool(self.report.wButtons & btn)))),
+                libevdev.InputEvent(key, value=int(bool(self.report.wButtons & btn))),
             ])
 
         for btn, key in self.DS4_SPECIAL_BUTTON_TO_EV_KEY.items():
             self.uinput.send_events([
-                libevdev.InputEvent(key, value=(int(bool(self.report.bSpecial & btn)))),
+                libevdev.InputEvent(key, value=int(bool(self.report.bSpecial & btn))),
             ])
 
-        # Update axes
         self.uinput.send_events([
-            # Left joystick
             libevdev.InputEvent(libevdev.EV_ABS.ABS_X, value=self.report.bThumbLX),
             libevdev.InputEvent(libevdev.EV_ABS.ABS_Y, value=self.report.bThumbLY),
-            # Right joystick
             libevdev.InputEvent(libevdev.EV_ABS.ABS_RX, value=self.report.bThumbRX),
             libevdev.InputEvent(libevdev.EV_ABS.ABS_RY, value=self.report.bThumbRY),
-            # Triggers
             libevdev.InputEvent(libevdev.EV_ABS.ABS_Z, value=self.report.bTriggerL),
-            libevdev.InputEvent(libevdev.EV_ABS.ABS_RZ, value=self.report.bTriggerR)
+            libevdev.InputEvent(libevdev.EV_ABS.ABS_RZ, value=self.report.bTriggerR),
         ])
 
-        hat0x_value, hat0y_value = self.dpad_mapping[self.dpad_direction]
+        hat0x_value, hat0y_value = self.DPAD_MAPPING[self.dpad_direction]
 
         self.uinput.send_events([
             libevdev.InputEvent(libevdev.EV_ABS.ABS_HAT0X, value=hat0x_value),
-            libevdev.InputEvent(libevdev.EV_ABS.ABS_HAT0Y, value=hat0y_value)
+            libevdev.InputEvent(libevdev.EV_ABS.ABS_HAT0Y, value=hat0y_value),
         ])
 
         self.uinput.send_events([libevdev.InputEvent(libevdev.EV_SYN.SYN_REPORT, value=0)])
 
-    def target_alloc(self):
+    def update_extended_report(self, extended_report: vcom.DS4_REPORT_EX) -> None:
+        """Send a DS4_REPORT_EX to the virtual device.
+
+        On Linux the standard gamepad fields are extracted and sent via
+        the normal update path.  Gyro, accelerometer, and touchpad
+        coordinate data are not emitted as evdev events.
+        """
+        sub = extended_report.Report
+
+        self.report.bThumbLX = sub.bThumbLX
+        self.report.bThumbLY = sub.bThumbLY
+        self.report.bThumbRX = sub.bThumbRX
+        self.report.bThumbRY = sub.bThumbRY
+        self.report.wButtons = sub.wButtons
+        self.report.bSpecial = sub.bSpecial
+        self.report.bTriggerL = sub.bTriggerL
+        self.report.bTriggerR = sub.bTriggerR
+
+        self.dpad_direction = vcom.DS4_DPAD_DIRECTIONS(sub.wButtons & 0xF)
+
+        self.update()
+
+    def target_alloc(self) -> Any:
         return self.uinput

--- a/vgamepad/win/vigem_client.py
+++ b/vgamepad/win/vigem_client.py
@@ -1,16 +1,14 @@
-"""
-Adapted from ViGEm source
-"""
+"""ViGEm client DLL bindings - adapted from ViGEm source."""
+
+from __future__ import annotations
 
 import platform
+from ctypes import CDLL, POINTER, c_bool, c_uint, c_ulong, c_ushort, c_void_p
 from pathlib import Path
-from ctypes import CDLL, POINTER, CFUNCTYPE, c_void_p, c_uint, c_ushort, c_ulong, c_bool, c_ubyte
-from vgamepad.win.vigem_commons import XUSB_REPORT, DS4_REPORT, DS4_REPORT_EX, VIGEM_TARGET_TYPE
 
-if platform.architecture()[0] == "64bit":
-    arch = "x64"
-else:
-    arch = "x86"
+from vgamepad.win.vigem_commons import DS4_REPORT, DS4_REPORT_EX, VIGEM_TARGET_TYPE, XUSB_REPORT
+
+arch = "x64" if platform.architecture()[0] == "64bit" else "x86"
 
 pathClient = Path(__file__).parent.absolute() / "vigem" / "client" / arch / "ViGEmClient.dll"
 vigemClient = CDLL(str(pathClient))

--- a/vgamepad/win/vigem_commons.py
+++ b/vgamepad/win/vigem_commons.py
@@ -1,12 +1,11 @@
-"""
-Adapted from ViGEm source
-"""
+"""ViGEm common types - adapted from the ViGEm C source headers."""
 
-from enum import IntFlag, IntEnum
-from ctypes import Structure, Union, c_short, c_ushort, c_ubyte
+from __future__ import annotations
 
+from ctypes import Structure, Union, c_short, c_ubyte, c_ushort
+from enum import IntEnum, IntFlag
 
-c_byte = c_ubyte  # because BYTE is actually unsigned char
+c_byte = c_ubyte  # BYTE in C is unsigned char
 
 
 class VIGEM_TARGET_TYPE(IntFlag):
@@ -118,7 +117,7 @@ class DS4_REPORT(Structure):
 
 def DS4_SET_DPAD(report, dpad):
     report.wButtons &= ~0xF
-    report.wButtons |= dpad  # TODO cast USHORT?
+    report.wButtons |= dpad
 
 
 def DS4_REPORT_INIT(report):
@@ -197,6 +196,3 @@ class VIGEM_ERRORS(IntEnum):
     VIGEM_ERROR_XUSB_USERINDEX_OUT_OF_RANGE = 0xE0000014
     VIGEM_ERROR_INVALID_PARAMETER = 0xE0000015
     VIGEM_ERROR_NOT_SUPPORTED = 0xE0000016
-
-
-# TODO: add the missing types (C callback functions)

--- a/vgamepad/win/virtual_gamepad.py
+++ b/vgamepad/win/virtual_gamepad.py
@@ -1,122 +1,106 @@
-"""
-VGamepad API (Windows)
-"""
+"""VGamepad API (Windows) - ViGEm backend."""
 
-import vgamepad.win.vigem_commons as vcom
-import vgamepad.win.vigem_client as vcli
+from __future__ import annotations
+
 import ctypes
-from ctypes import CFUNCTYPE, c_void_p, c_ubyte
 from abc import ABC, abstractmethod
-from inspect import signature  # Check if user defined callback function is legal
+from collections.abc import Callable
+from ctypes import CFUNCTYPE, c_ubyte, c_void_p
+from inspect import signature
+from typing import Any
+
+import vgamepad.win.vigem_client as vcli
+import vgamepad.win.vigem_commons as vcom
 
 
-def check_err(err):
+def _check_err(err: int) -> None:
     if err != vcom.VIGEM_ERRORS.VIGEM_ERROR_NONE:
         raise Exception(vcom.VIGEM_ERRORS(err).name)
 
 
-def dummy_callback(client, target, large_motor, small_motor, led_number, user_data):
-    """
-    Pattern for callback functions to be registered as notifications
-
-    :param client: vigem bus ID
-    :param target: vigem device ID
-    :param large_motor: integer in [0, 255] representing the state of the large motor
-    :param small_motor: integer in [0, 255] representing the state of the small motor
-    :param led_number: integer in [0, 255] representing the state of the LED ring
-    :param user_data: placeholder, do not use
-    """
-    pass
+def _dummy_callback(
+    client: Any,
+    target: Any,
+    large_motor: int,
+    small_motor: int,
+    led_number: int,
+    user_data: Any,
+) -> None:
+    """Reference signature for notification callbacks."""
 
 
 class VBus:
-    """
-    Virtual USB bus (ViGEmBus)
-    """
-    def __init__(self):
-        self._busp = vcli.vigem_alloc()
-        check_err(vcli.vigem_connect(self._busp))
+    """Virtual USB bus (ViGEmBus)."""
 
-    def get_busp(self):
+    def __init__(self) -> None:
+        self._busp = vcli.vigem_alloc()
+        _check_err(vcli.vigem_connect(self._busp))
+
+    def get_busp(self) -> Any:
         return self._busp
 
-    def __del__(self):
+    def __del__(self) -> None:
         vcli.vigem_disconnect(self._busp)
         vcli.vigem_free(self._busp)
 
 
-# We instantiate a single global VBus for all controllers
 VBUS = VBus()
 
 
 class VGamepad(ABC):
-    def __init__(self):
+    def __init__(self) -> None:
         self.vbus = VBUS
         self._busp = self.vbus.get_busp()
         self._devicep = self.target_alloc()
         self.CMPFUNC = CFUNCTYPE(None, c_void_p, c_void_p, c_ubyte, c_ubyte, c_ubyte, c_void_p)
-        self.cmp_func = None
+        self.cmp_func: Any | None = None
         vcli.vigem_target_add(self._busp, self._devicep)
-        assert vcli.vigem_target_is_attached(self._devicep), "The virtual device could not connect to ViGEmBus."
+        if not vcli.vigem_target_is_attached(self._devicep):
+            raise RuntimeError("The virtual device could not connect to ViGEmBus.")
 
-    def __del__(self):
+    def __del__(self) -> None:
         vcli.vigem_target_remove(self._busp, self._devicep)
         vcli.vigem_target_free(self._devicep)
 
-    def get_vid(self):
-        """
-        :return: the vendor ID of the virtual device
-        """
+    def get_vid(self) -> int:
+        """Return the vendor ID of the virtual device."""
         return vcli.vigem_target_get_vid(self._devicep)
 
-    def get_pid(self):
-        """
-        :return: the product ID of the virtual device
-        """
+    def get_pid(self) -> int:
+        """Return the product ID of the virtual device."""
         return vcli.vigem_target_get_pid(self._devicep)
 
-    def set_vid(self, vid):
-        """
-        :param: the new vendor ID of the virtual device
-        """
+    def set_vid(self, vid: int) -> None:
+        """Set the vendor ID of the virtual device."""
         vcli.vigem_target_set_vid(self._devicep, vid)
 
-    def set_pid(self, pid):
-        """
-        :param: the new product ID of the virtual device
-        """
+    def set_pid(self, pid: int) -> None:
+        """Set the product ID of the virtual device."""
         vcli.vigem_target_set_pid(self._devicep, pid)
 
-    def get_index(self):
-        """
-        :return: the internally used index of the target device
-        """
+    def get_index(self) -> int:
+        """Return the internally used index of the target device."""
         return vcli.vigem_target_get_index(self._devicep)
 
-    def get_type(self):
-        """
-        :return: the type of the object (e.g. VIGEM_TARGET_TYPE.Xbox360Wired)
-        """
+    def get_type(self) -> Any:
+        """Return the type of the object (e.g. ``VIGEM_TARGET_TYPE.Xbox360Wired``)."""
         return vcli.vigem_target_get_type(self._devicep)
 
     @abstractmethod
-    def target_alloc(self):
-        """
-        :return: the pointer to an allocated ViGEm device (e.g. vcli.vigem_target_x360_alloc())
-        """
-        pass
+    def target_alloc(self) -> Any:
+        """Return the pointer to an allocated ViGEm device."""
+        ...
 
 
 class VX360Gamepad(VGamepad):
-    """
-    Virtual XBox360 gamepad
-    """
-    def __init__(self):
+    """Virtual Xbox 360 gamepad (Windows / ViGEm)."""
+
+    def __init__(self) -> None:
         super().__init__()
         self.report = self.get_default_report()
         self.update()
 
-    def get_default_report(self):
+    def get_default_report(self) -> vcom.XUSB_REPORT:
         return vcom.XUSB_REPORT(
             wButtons=0,
             bLeftTrigger=0,
@@ -124,136 +108,95 @@ class VX360Gamepad(VGamepad):
             sThumbLX=0,
             sThumbLY=0,
             sThumbRX=0,
-            sThumbRY=0)
+            sThumbRY=0,
+        )
 
-    def reset(self):
-        """
-        Resets the report to the default state
-        """
+    def reset(self) -> None:
+        """Reset the report to the default state."""
         self.report = self.get_default_report()
 
-    def press_button(self, button):
-        """
-        Presses a button (no effect if already pressed)
-        All possible buttons are in XUSB_BUTTON
+    def press_button(self, button: vcom.XUSB_BUTTON) -> None:
+        """Press a button (no effect if already pressed).
 
-        :param: a XUSB_BUTTON field, e.g. XUSB_BUTTON.XUSB_GAMEPAD_X
+        :param button: an ``XUSB_BUTTON`` field, e.g. ``XUSB_BUTTON.XUSB_GAMEPAD_X``
         """
         self.report.wButtons = self.report.wButtons | button
 
-    def release_button(self, button):
-        """
-        Releases a button (no effect if already released)
-        All possible buttons are in XUSB_BUTTON
+    def release_button(self, button: vcom.XUSB_BUTTON) -> None:
+        """Release a button (no effect if already released).
 
-        :param: a XUSB_BUTTON field, e.g. XUSB_BUTTON.XUSB_GAMEPAD_X
+        :param button: an ``XUSB_BUTTON`` field, e.g. ``XUSB_BUTTON.XUSB_GAMEPAD_X``
         """
         self.report.wButtons = self.report.wButtons & ~button
 
-    def left_trigger(self, value):
-        """
-        Sets the value of the left trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def left_trigger(self, value: int) -> None:
+        """Set the left trigger value (0-255, 0 = released)."""
         self.report.bLeftTrigger = value
 
-    def right_trigger(self, value):
-        """
-        Sets the value of the right trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def right_trigger(self, value: int) -> None:
+        """Set the right trigger value (0-255, 0 = released)."""
         self.report.bRightTrigger = value
 
-    def left_trigger_float(self, value_float):
-        """
-        Sets the value of the left trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def left_trigger_float(self, value_float: float) -> None:
+        """Set the left trigger value (0.0-1.0, 0.0 = released)."""
         self.left_trigger(round(value_float * 255))
 
-    def right_trigger_float(self, value_float):
-        """
-        Sets the value of the right trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def right_trigger_float(self, value_float: float) -> None:
+        """Set the right trigger value (0.0-1.0, 0.0 = released)."""
         self.right_trigger(round(value_float * 255))
 
-    def left_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the left joystick
-
-        :param: integer between -32768 and 32767 (0 = neutral position)
-        """
+    def left_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the left joystick axes (-32768 to 32767, 0 = neutral)."""
         self.report.sThumbLX = x_value
         self.report.sThumbLY = y_value
 
-    def right_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: integer between -32768 and 32767 (0 = neutral position)
-        """
+    def right_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the right joystick axes (-32768 to 32767, 0 = neutral)."""
         self.report.sThumbRX = x_value
         self.report.sThumbRY = y_value
 
-    def left_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the left joystick
-
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
+    def left_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the left joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
         self.left_joystick(round(x_value_float * 32767), round(y_value_float * 32767))
 
-    def right_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
+    def right_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the right joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
         self.right_joystick(round(x_value_float * 32767), round(y_value_float * 32767))
 
-    def update(self):
-        """
-        Sends the current report (i.e. commands) to the virtual device
-        """
-        check_err(vcli.vigem_target_x360_update(self._busp, self._devicep, self.report))
+    def update(self) -> None:
+        """Send the current report to the virtual device."""
+        _check_err(vcli.vigem_target_x360_update(self._busp, self._devicep, self.report))
 
-    def register_notification(self, callback_function):
-        """
-        Registers a callback function that can handle force feedback, leds, etc.
+    def register_notification(self, callback_function: Callable[..., Any]) -> None:
+        """Register a callback for force feedback, LEDs, etc.
 
-        :param: a function of the form: my_func(client, target, large_motor, small_motor, led_number, user_data)
+        :param callback_function: ``f(client, target, large_motor, small_motor, led_number, user_data)``
         """
-        if not signature(callback_function) == signature(dummy_callback):
-            raise TypeError("Needed callback function signature: {}, but got: {}".format(signature(dummy_callback), signature(callback_function)))
-        self.cmp_func = self.CMPFUNC(callback_function)  # keep its reference, otherwise the program will crash when a callback is made.
-        check_err(vcli.vigem_target_x360_register_notification(self._busp, self._devicep, self.cmp_func, None))
+        if signature(callback_function) != signature(_dummy_callback):
+            raise TypeError(
+                f"Expected callback signature: {signature(_dummy_callback)}, "
+                f"got: {signature(callback_function)}"
+            )
+        self.cmp_func = self.CMPFUNC(callback_function)
+        _check_err(vcli.vigem_target_x360_register_notification(self._busp, self._devicep, self.cmp_func, None))
 
-    def unregister_notification(self):
-        """
-        Unregisters a previously registered callback function.
-        """
+    def unregister_notification(self) -> None:
+        """Unregister a previously registered callback function."""
         vcli.vigem_target_x360_unregister_notification(self._devicep)
 
-    def target_alloc(self):
+    def target_alloc(self) -> Any:
         return vcli.vigem_target_x360_alloc()
 
 
 class VDS4Gamepad(VGamepad):
-    """
-    Virtual DualShock 4 gamepad
-    """
+    """Virtual DualShock 4 gamepad (Windows / ViGEm)."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.report = self.get_default_report()
         self.update()
 
-    def get_default_report(self):
+    def get_default_report(self) -> vcom.DS4_REPORT:
         rep = vcom.DS4_REPORT(
             bThumbLX=0,
             bThumbLY=0,
@@ -262,158 +205,111 @@ class VDS4Gamepad(VGamepad):
             wButtons=0,
             bSpecial=0,
             bTriggerL=0,
-            bTriggerR=0)
+            bTriggerR=0,
+        )
         vcom.DS4_REPORT_INIT(rep)
         return rep
 
-    def reset(self):
-        """
-        Resets the report to the default state
-        """
+    def reset(self) -> None:
+        """Reset the report to the default state."""
         self.report = self.get_default_report()
 
-    def press_button(self, button):
-        """
-        Presses a button (no effect if already pressed)
-        All possible buttons are in DS4_BUTTONS
+    def press_button(self, button: vcom.DS4_BUTTONS) -> None:
+        """Press a button (no effect if already pressed).
 
-        :param: a DS4_BUTTONS field, e.g. DS4_BUTTONS.DS4_BUTTON_TRIANGLE
+        :param button: a ``DS4_BUTTONS`` field, e.g. ``DS4_BUTTONS.DS4_BUTTON_TRIANGLE``
         """
         self.report.wButtons = self.report.wButtons | button
 
-    def release_button(self, button):
-        """
-        Releases a button (no effect if already released)
-        All possible buttons are in DS4_BUTTONS
+    def release_button(self, button: vcom.DS4_BUTTONS) -> None:
+        """Release a button (no effect if already released).
 
-        :param: a DS4_BUTTONS field, e.g. DS4_BUTTONS.DS4_BUTTON_TRIANGLE
+        :param button: a ``DS4_BUTTONS`` field, e.g. ``DS4_BUTTONS.DS4_BUTTON_TRIANGLE``
         """
         self.report.wButtons = self.report.wButtons & ~button
 
-    def press_special_button(self, special_button):
-        """
-        Presses a special button (no effect if already pressed)
-        All possible buttons are in DS4_SPECIAL_BUTTONS
+    def press_special_button(self, special_button: vcom.DS4_SPECIAL_BUTTONS) -> None:
+        """Press a special button (no effect if already pressed).
 
-        :param: a DS4_SPECIAL_BUTTONS field, e.g. DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD
+        :param special_button: a ``DS4_SPECIAL_BUTTONS`` field
         """
         self.report.bSpecial = self.report.bSpecial | special_button
 
-    def release_special_button(self, special_button):
-        """
-        Releases a special button (no effect if already released)
-        All possible buttons are in DS4_SPECIAL_BUTTONS
+    def release_special_button(self, special_button: vcom.DS4_SPECIAL_BUTTONS) -> None:
+        """Release a special button (no effect if already released).
 
-        :param: a DS4_SPECIAL_BUTTONS field, e.g. DS4_SPECIAL_BUTTONS.DS4_SPECIAL_BUTTON_TOUCHPAD
+        :param special_button: a ``DS4_SPECIAL_BUTTONS`` field
         """
         self.report.bSpecial = self.report.bSpecial & ~special_button
 
-    def left_trigger(self, value):
-        """
-        Sets the value of the left trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def left_trigger(self, value: int) -> None:
+        """Set the left trigger value (0-255, 0 = released)."""
         self.report.bTriggerL = value
 
-    def right_trigger(self, value):
-        """
-        Sets the value of the right trigger
-
-        :param: integer between 0 and 255 (0 = trigger released)
-        """
+    def right_trigger(self, value: int) -> None:
+        """Set the right trigger value (0-255, 0 = released)."""
         self.report.bTriggerR = value
 
-    def left_trigger_float(self, value_float):
-        """
-        Sets the value of the left trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def left_trigger_float(self, value_float: float) -> None:
+        """Set the left trigger value (0.0-1.0, 0.0 = released)."""
         self.left_trigger(round(value_float * 255))
 
-    def right_trigger_float(self, value_float):
-        """
-        Sets the value of the right trigger
-
-        :param: float between 0.0 and 1.0 (0.0 = trigger released)
-        """
+    def right_trigger_float(self, value_float: float) -> None:
+        """Set the right trigger value (0.0-1.0, 0.0 = released)."""
         self.right_trigger(round(value_float * 255))
 
-    def left_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the left joystick
-
-        :param: integer between 0 and 255 (128 = neutral position)
-        """
+    def left_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the left joystick axes (0-255, 128 = neutral)."""
         self.report.bThumbLX = x_value
         self.report.bThumbLY = y_value
 
-    def right_joystick(self, x_value, y_value):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: integer between 0 and 255 (128 = neutral position)
-        """
+    def right_joystick(self, x_value: int, y_value: int) -> None:
+        """Set the right joystick axes (0-255, 128 = neutral)."""
         self.report.bThumbRX = x_value
         self.report.bThumbRY = y_value
 
-    def left_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the left joystick
-
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
+    def left_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the left joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
         self.left_joystick(128 + round(x_value_float * 127), 128 + round(y_value_float * 127))
 
-    def right_joystick_float(self, x_value_float, y_value_float):
-        """
-        Sets the values of the X and Y axis for the right joystick
-
-        :param: float between -1.0 and 1.0 (0 = neutral position)
-        """
+    def right_joystick_float(self, x_value_float: float, y_value_float: float) -> None:
+        """Set the right joystick axes (-1.0 to 1.0, 0.0 = neutral)."""
         self.right_joystick(128 + round(x_value_float * 127), 128 + round(y_value_float * 127))
 
-    def directional_pad(self, direction):
-        """
-        Sets the direction of the directional pad (hat)
-        All possible directions are in DS4_DPAD_DIRECTIONS
+    def directional_pad(self, direction: vcom.DS4_DPAD_DIRECTIONS) -> None:
+        """Set the directional pad (hat) direction.
 
-        :param: a DS4_DPAD_DIRECTIONS field, e.g. DS4_DPAD_DIRECTIONS.DS4_BUTTON_DPAD_NORTHWEST
+        :param direction: a ``DS4_DPAD_DIRECTIONS`` field
         """
         vcom.DS4_SET_DPAD(self.report, direction)
 
-    def update(self):
-        """
-        Sends the current report (i.e. commands) to the virtual device
-        """
-        check_err(vcli.vigem_target_ds4_update(self._busp, self._devicep, self.report))
+    def update(self) -> None:
+        """Send the current report to the virtual device."""
+        _check_err(vcli.vigem_target_ds4_update(self._busp, self._devicep, self.report))
 
-    def update_extended_report(self, extended_report):
-        """
-        Enables using DS4_REPORT_EX instead of DS4_REPORT (advanced users only)
-        If you don't know what this is about, you can safely ignore this function
+    def update_extended_report(self, extended_report: vcom.DS4_REPORT_EX) -> None:
+        """Send a DS4_REPORT_EX to the virtual device (advanced users only).
 
-        :param: a DS4_REPORT_EX
+        :param extended_report: a ``DS4_REPORT_EX``
         """
-        check_err(vcli.vigem_target_ds4_update_ex_ptr(self._busp, self._devicep, ctypes.byref(extended_report)))
+        _check_err(vcli.vigem_target_ds4_update_ex_ptr(self._busp, self._devicep, ctypes.byref(extended_report)))
 
-    def register_notification(self, callback_function):
-        """
-        Registers a callback function that can handle force feedback, leds, etc.
+    def register_notification(self, callback_function: Callable[..., Any]) -> None:
+        """Register a callback for force feedback, LEDs, etc.
 
-        :param: a function of the form: my_func(client, target, large_motor, small_motor, led_number, user_data)
+        :param callback_function: ``f(client, target, large_motor, small_motor, led_number, user_data)``
         """
-        if not signature(callback_function) == signature(dummy_callback):
-            raise TypeError("Needed callback function signature: {}, but got: {}".format(signature(dummy_callback), signature(callback_function)))
+        if signature(callback_function) != signature(_dummy_callback):
+            raise TypeError(
+                f"Expected callback signature: {signature(_dummy_callback)}, "
+                f"got: {signature(callback_function)}"
+            )
         self.cmp_func = self.CMPFUNC(callback_function)
-        check_err(vcli.vigem_target_ds4_register_notification(self._busp, self._devicep, self.cmp_func, None))
+        _check_err(vcli.vigem_target_ds4_register_notification(self._busp, self._devicep, self.cmp_func, None))
 
-    def unregister_notification(self):
-        """
-        Unregisters a previously registered callback function.
-        """
+    def unregister_notification(self) -> None:
+        """Unregister a previously registered callback function."""
         vcli.vigem_target_ds4_unregister_notification(self._devicep)
 
-    def target_alloc(self):
+    def target_alloc(self) -> Any:
         return vcli.vigem_target_ds4_alloc()


### PR DESCRIPTION
This PR incorporates and builds upon the expanded Linux vgamepad support initially drafted by @Palamabron in PR #47 .

## chore: fixed rumble detection and pip conflict
- **Fix: Prevent process freeze during rumble on Linux & resolve pip conflict**

Rumble data was previously being sent to a new file descriptor instead of the active vgamepad descriptor. This caused the process to freeze while waiting for a response from the device.

The file descriptor is now retrieved directly from the /proc/self/fd directory, completely bypassing libevdev. 

Note on get_raw_uinput_fd:
The python-libevdev wrapper aggressively hides the underlying file descriptor for the uinput device. To avoid blocking the original fd and freezing the process, this fallback was implemented. 
*Known limitation:* If multiple virtual gamepads are instantiated in the same process, this method currently grabs the first available /dev/uinput fd.